### PR TITLE
Configuration updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 # salsify_rubocop
 
+## v0.40.1 (unreleased)
+- Changes to `rubocop_without_rspec` configuration:
+
+        Performance/RedundantMerge:
+          MaxKeyValuePairs: 1
+
+        Style/ModuleFunction:
+          Enabled: false
+
+        Style/RaiseArgs:
+          EnforcedStyle: compact
+
 ## v0.40.0
 - Initial version

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -12,6 +12,9 @@ AllCops:
 Lint/AmbiguousOperator:
   Enabled: false
 
+Performance/RedundantMerge:
+  MaxKeyValuePairs: 1
+
 Style/Alias:
   EnforcedStyle: prefer_alias_method
 
@@ -54,6 +57,9 @@ Style/GuardClause:
 Style/Lambda:
   Enabled: false
 
+Style/ModuleFunction:
+  Enabled: false
+
 Style/MultilineMethodCallIndentation:
   Enabled: false
 
@@ -65,6 +71,9 @@ Style/MultilineBlockLayout:
 
 Style/Proc:
   Enabled: false
+
+Style/RaiseArgs:
+  EnforcedStyle: compact
 
 Style/RegexpLiteral:
   Enabled: false

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SalsifyRubocop
-  VERSION = '0.40.0'.freeze
+  VERSION = '0.40.1'.freeze
 end


### PR DESCRIPTION
For background, this gem contains specific version dependencies for rubocop and rubocop-rspec
and shared configuration that we're using for newer applications and gems.

The configuration changes here represent overrides that have been used in multiple repos recently:
- Style/ModuleFunction: This prefers `module_function` over `extend self`. We don't want that.
- Style/RaiseArgs: The 'compact' style selected here prefers:

``` ruby
# good
raise SomeError.new('foo')

# bad
raise SomeError, 'foo'
```
- Performance/RedundantMerge: This cop recommends against the use of `merge!`. It's configurable based on the number of keys passed to `merge!`. It prefers:

``` ruby
# according to the cop
# bad
hash.merge!(one: 1, two: 2)

# good
hash[:one] = 1
hash[:two] = 2
```

The configuration here only allows it to complain when `merge!` has a single key, i.e.:

``` ruby
hash.merge!(one: 1)
# can be replaced by
hash[:one] = 1
```

Prime: @fgarces 
