### PR TITLE
Add Salsify/RspecDocString and update to RuboCop v0.42

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,4 @@
+--order rand
 --format documentation
 --color
+--require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_from:
+  - conf/rubocop.yml
+
 Metrics/LineLength:
   Exclude:
     - '*.gemspec'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 rvm:
+  - 2.2.4
   - 2.3.1
-before_install: gem install bundler -v 1.12.4
-
+script:
+  - bundle exec rubocop
+  - bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # salsify_rubocop
 
+## v0.42.0
+- Update to RuboCop v0.42.
+- Add `Salsify/RspecDocString` cop to check quoting for examples/example groups.
+
 ## v0.41.0
 - `.ruby-version` can be used to determine TargetRubyVersion in RuboCop v0.41
 - Change to `rubocop_rails` configuration:

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -1,7 +1,12 @@
 inherit_from:
   - ../conf/rubocop_without_rspec.yml
 
-require: rubocop-rspec
+require: salsify_rubocop
+
+# See https://github.com/bbatsov/rubocop/pull/3343
+Style/NumericPredicate:
+  Exclude:
+    - 'spec/**/*'
 
 RSpec/DescribeClass:
   Enabled: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,0 +1,9 @@
+Salsify/RspecDocString:
+  Description: 'Check that RSpec doc strings use the correct quoting.'
+  Enabled: true
+  EnforcedStyle: double_quotes
+  SupportedStyles:
+    - single_quotes
+    - double_quotes
+  Include:
+    - 'spec/**/*'

--- a/lib/rubocop/cop/salsify/rspec_doc_string.rb
+++ b/lib/rubocop/cop/salsify/rspec_doc_string.rb
@@ -1,0 +1,84 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Salsify
+      # Check that doc strings for example groups and examples use either
+      # single-quoted or double-quoted strings based on the enforced style.
+      #
+      # This cop is disabled by default.
+      #
+      # @example
+      #
+      #   # When EnforcedStyle is double_quotes
+      #   # Good
+      #   it "does something" do
+      #     ...
+      #   end
+      #
+      #   # When EnforcedStyle is single_quotes
+      #   # Good
+      #   it 'does something' do
+      #     ...
+      #   end
+      class RspecDocString < Cop
+        include ConfigurableEnforcedStyle
+
+        SINGLE_QUOTE_MSG =
+          'Example Group/Example doc strings must be single-quoted.'.freeze
+        DOUBLE_QUOTE_MSG =
+          'Example Group/Example doc strings must be double-quoted.'.freeze
+
+        DOCUMENTED_METHODS = [
+          :example_group, :describe, :context, :xdescribe, :xcontext,
+          :it, :example, :specify, :xit, :xexample, :xspecify,
+          :feature, :scenario, :xfeature, :xscenario,
+          :fdescribe, :fcontext, :focus, :fexample, :fit, :fspecify,
+          :ffeature, :fscenario
+        ].to_set.freeze
+
+        def on_send(node)
+          _receiver, method_name, *args = *node
+          return unless DOCUMENTED_METHODS.include?(method_name) &&
+            !args.empty? && args.first.str_type?
+
+          check_quotes(args.first)
+        end
+
+        private
+
+        def check_quotes(doc_node)
+          if wrong_quotes?(doc_node)
+            if style == :single_quotes
+              add_offense(doc_node, :expression, SINGLE_QUOTE_MSG)
+            else
+              add_offense(doc_node, :expression, DOUBLE_QUOTE_MSG)
+            end
+          end
+        end
+
+        def wrong_quotes?(node)
+          src = node.source
+          return false if src.start_with?('%', '?')
+          if style == :single_quotes
+            src !~ /^'/ && !double_quotes_acceptable?(node.str_content)
+          else
+            src !~ /^" | \\ | \#/x
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            str = node.str_content
+            if style == :single_quotes
+              corrector.replace(node.source_range, to_string_literal(str))
+            else
+              corrector.replace(node.source_range, str.inspect)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/salsify_rubocop.rb
+++ b/lib/salsify_rubocop.rb
@@ -1,5 +1,16 @@
 require 'salsify_rubocop/version'
+require 'rubocop-rspec'
 
-# Top-level gem module
-module SalsifyRubocop
-end
+# Because RuboCop doesn't yet support plugins, we have to monkey patch in a
+# bit of our configuration. Based on approach from rubocop-rspec:
+DEFAULT_FILES = File.expand_path('../../config/default.yml', __FILE__)
+
+path = File.absolute_path(DEFAULT_FILES)
+hash = RuboCop::ConfigLoader.send(:load_yaml_configuration, path)
+config = RuboCop::Config.new(hash, path)
+puts "configuration from #{DEFAULT_FILES}" if RuboCop::ConfigLoader.debug?
+config = RuboCop::ConfigLoader.merge_with_default(config, path)
+RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
+
+# cops
+require 'rubocop/cop/salsify/rspec_doc_string'

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SalsifyRubocop
-  VERSION = '0.41.0'.freeze
+  VERSION = '0.42.0'.freeze
 end

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.41.2'
-  spec.add_runtime_dependency 'rubocop-rspec', '~> 1.5.0'
+  spec.add_runtime_dependency 'rubocop', '~> 0.42.0'
+  spec.add_runtime_dependency 'rubocop-rspec', '~> 1.5.1'
 end

--- a/spec/rubocop/cop/salsify/rspec_doc_string_spec.rb
+++ b/spec/rubocop/cop/salsify/rspec_doc_string_spec.rb
@@ -1,0 +1,73 @@
+# encoding utf-8
+
+describe RuboCop::Cop::Salsify::RspecDocString, :config do
+  subject(:cop) { described_class.new(config) }
+
+  shared_examples_for 'always accepted strings' do |name|
+    it "accepts `#{name}` with a single character" do
+      inspect_source(cop, ["#{name} ?a do", 'end'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it "accepts `#{name}` with a %q string" do
+      inspect_source(cop, ["#{name} %q(doc string) do", 'end'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it "accepts `#{name}` with a string the requires interpolation" do
+      doc_string = '"#{\'DOC\'.downcase} string"'
+      inspect_source(cop, ["#{name} #{doc_string} do", 'end'])
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  context "when the enforced style is `double_quotes` (default)" do
+    let(:cop_config) { { 'EnforcedStyle' => 'double_quotes', 'Include' => ['**/*'] } }
+
+    described_class::DOCUMENTED_METHODS.each do |name|
+      it "finds `#{name}` with a single-quoted string" do
+        source = ["#{name} 'doc string' do", 'end']
+        inspect_source(cop, source)
+        expect(cop.messages).to eq([described_class::DOUBLE_QUOTE_MSG])
+        expect(cop.highlights).to eq(["'doc string'"])
+        expect(autocorrect_source(cop, source))
+          .to eq("#{name} \"doc string\" do\nend")
+      end
+
+      it "accepts `#{name}` with a double-quoted string" do
+        inspect_source(cop,
+                       [
+                         "#{name} \"doc string\" do",
+                         'end'
+                       ])
+        expect(cop.offenses).to be_empty
+      end
+
+      it_behaves_like 'always accepted strings', name
+    end
+  end
+
+  context "when the enforced style is `single_quotes`" do
+    let(:cop_config) { { 'EnforcedStyle' => 'single_quotes', 'Include' => ['**/*'] } }
+
+    described_class::DOCUMENTED_METHODS.each do |name|
+      it "finds `#{name}` with a double-quoted string" do
+        source = ["#{name} \"doc string\" do", 'end']
+        inspect_source(cop, source)
+        expect(cop.messages).to eq([described_class::SINGLE_QUOTE_MSG])
+        expect(cop.highlights).to eq(['"doc string"'])
+        expect(autocorrect_source(cop, source))
+          .to eq("#{name} 'doc string' do\nend")
+      end
+
+      it "accepts `#{name}` with a single-quoted string" do
+        inspect_source(cop,
+                       [
+                         "#{name} 'doc string' do",
+                         'end'
+                       ])
+        expect(cop.offenses).to be_empty
+      end
+    end
+  end
+end

--- a/spec/salsify_rubocop_spec.rb
+++ b/spec/salsify_rubocop_spec.rb
@@ -1,7 +1,5 @@
-require 'spec_helper'
-
 describe SalsifyRubocop do
-  it 'has a version number' do
+  it "has a version number" do
     expect(SalsifyRubocop::VERSION).not_to be nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,4 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'salsify_rubocop'
+
+require 'rubocop/rspec/support'


### PR DESCRIPTION
This gem includes a cop that I wrote a while ago to enforce that doc strings used with RSpec use double quotes. That cop was submitted to `rubocop-rspec` and eventually rejected as being too obscure.

I've added it here as a custom cop: `Salsify/RspecDocString`.

I also did some work on a cop to enforce a style on the non-doc strings within specs. The idea being that you can use one convention for doc strings (double quotes), but enforce another (single quotes) for the code. Tests still need to be completed for that cop as I was waiting to see what happened with `rubocop-rspec`, and therefore it is not included here.

Prime: @jturkel 
