### PR TITLE
Update for rubocop 0.43, rubocop-rspec 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   using `Style/AlignHash`.
 - Add `Salsify/RspecStringLiterals` cop to check non-doc string quotes for
   examples/example groups.
+- Modify `Salsify/RspecDocString` to treat names for shared groups and shared
+  example as doc strings.
 
 ## v0.42.0
 - Update to RuboCop v0.42.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # salsify_rubocop
 
+## v0.43.0
+- Update to `rubocop` v0.43.0.
+- Update to `rubocop-rspec` v1.7.0.
+- Disable new RSpec cops: `LeadingSubject`, `LetSetup`, `MultipleExpectations`,
+  and `NestedGroups`.
+- Disable new cop `RSpec/ExpectActual` for routing specs.
+- Disable problematic cops `Style/NumericPredicate`, `Style/SafeNavigation`,
+  and `Style/VariableNumber`.
+- Disable `Style/IndentHash`, which applies to the first line, since we are not
+  using `Style/AlignHash`.
+- Add `Salsify/RspecStringLiterals` cop to check non-doc string quotes for
+  examples/example groups.
+
 ## v0.42.0
 - Update to RuboCop v0.42.
 - Add `Salsify/RspecDocString` cop to check quoting for examples/example groups.

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -15,6 +15,7 @@ RSpec/DescribeMethod:
 RSpec/ExampleLength:
   Enabled: false
 
+# See https://github.com/backus/rubocop-rspec/issues/198
 RSpec/ExpectActual:
   Exclude:
   - 'spec/routing/**/*'

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -3,11 +3,6 @@ inherit_from:
 
 require: salsify_rubocop
 
-# See https://github.com/bbatsov/rubocop/pull/3343
-Style/NumericPredicate:
-  Exclude:
-    - 'spec/**/*'
-
 RSpec/DescribeClass:
   Enabled: false
 
@@ -20,5 +15,21 @@ RSpec/DescribeMethod:
 RSpec/ExampleLength:
   Enabled: false
 
+RSpec/ExpectActual:
+  Exclude:
+  - 'spec/routing/**/*'
+
 RSpec/InstanceVariable:
+  Enabled: false
+
+RSpec/LeadingSubject:
+  Enabled: false
+
+RSpec/LetSetup:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/NestedGroups:
   Enabled: false

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -58,6 +58,10 @@ Style/FrozenStringLiteralComment:
 Style/GuardClause:
   Enabled: false
 
+# does not make sense to enable this without AlignHash
+Style/IndentHash:
+  Enabled: false
+
 Style/Lambda:
   Enabled: false
 
@@ -77,6 +81,10 @@ Style/MultilineBlockLayout:
 Style/NumericLiteralPrefix:
   Enabled: false
 
+# This cop is problematic when nil may be compared with 0.
+Style/NumericPredicate:
+  Enabled: false
+
 Style/Proc:
   Enabled: false
 
@@ -84,6 +92,9 @@ Style/RaiseArgs:
   EnforcedStyle: compact
 
 Style/RegexpLiteral:
+  Enabled: false
+
+Style/SafeNavigation:
   Enabled: false
 
 # This cop doesn't work properly if you a have a block with
@@ -98,6 +109,9 @@ Style/StringLiterals:
   EnforcedStyle: single_quotes
   Exclude:
     - 'spec/**/*'
+
+Style/VariableNumber:
+  Enabled: false
 
 Metrics/AbcSize:
   Enabled: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -7,3 +7,14 @@ Salsify/RspecDocString:
     - double_quotes
   Include:
     - 'spec/**/*'
+
+Salsify/RspecStringLiterals:
+  Description: 'Enforce consistent quote style for non-doc strings in RSpec tests.'
+  Enabled: true
+  EnforcedStyle: single_quotes
+  SupportedStyles:
+    - single_quotes
+    - double_quotes
+#  Include:
+#    - 'spec/**/*'
+

--- a/lib/rubocop/cop/salsify/rspec_doc_string.rb
+++ b/lib/rubocop/cop/salsify/rspec_doc_string.rb
@@ -30,13 +30,14 @@ module RuboCop
         DOUBLE_QUOTE_MSG =
           'Example Group/Example doc strings must be double-quoted.'.freeze
 
-        DOCUMENTED_METHODS = [
-          :example_group, :describe, :context, :xdescribe, :xcontext,
-          :it, :example, :specify, :xit, :xexample, :xspecify,
-          :feature, :scenario, :xfeature, :xscenario,
-          :fdescribe, :fcontext, :focus, :fexample, :fit, :fspecify,
-          :ffeature, :fscenario
-        ].to_set.freeze
+        SHARED_EXAMPLES = RuboCop::RSpec::Language::SelectorSet.new(
+          %i(include_examples it_behaves_like it_should_behave_like include_context)
+        ).freeze
+
+        DOCUMENTED_METHODS = (RuboCop::RSpec::Language::ExampleGroups::ALL +
+          RuboCop::RSpec::Language::Examples::ALL +
+          RuboCop::RSpec::Language::SharedGroups::ALL +
+          SHARED_EXAMPLES).freeze
 
         def on_send(node)
           _receiver, method_name, *args = *node

--- a/lib/rubocop/cop/salsify/rspec_string_literals.rb
+++ b/lib/rubocop/cop/salsify/rspec_string_literals.rb
@@ -1,0 +1,48 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Salsify
+
+      # This cop checks if quotes match the configured preference. It is
+      # intended to be use specifically for specs and in combination with
+      # Salsify/RspecDocString.
+      #
+      # Used together with Salsify/RspecDocString it allows one quote style to
+      # be used for doc strings (`describe "foobar"`) and another style to be
+      # used for all other strings in specs.
+      class RspecStringLiterals < Cop
+        include ConfigurableEnforcedStyle
+        include StringLiteralsHelp
+
+        DOCUMENTED_METHODS = RuboCop::Cop::Salsify::RspecDocString::DOCUMENTED_METHODS
+
+        SINGLE_QUOTE_MSG = 'Prefer single-quoted strings unless you need ' \
+          'interpolation or special symbols.'.freeze
+        DOUBLE_QUOTE_MSG = 'Prefer double-quoted strings unless you need ' \
+          'single quotes to avoid extra backslashes for escaping.'.freeze
+
+        private
+
+        def message(*)
+          style == :single_quotes ? SINGLE_QUOTE_MSG : DOUBLE_QUOTE_MSG
+        end
+
+        # Share implementation with Style/StringLiterals from rubocop
+        def offense?(node)
+          return false if documented_parent?(node)
+          return false if inside_interpolation?(node)
+
+          wrong_quotes?(node)
+        end
+
+        def documented_parent?(node)
+          parent = node.parent
+          parent && parent.send_type? &&
+            DOCUMENTED_METHODS.include?(parent.children[1])
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/rspec/language/each_selector.rb
+++ b/lib/rubocop/rspec/language/each_selector.rb
@@ -1,0 +1,7 @@
+# Monkey-patch SelectorSet to allow enumeration of selectors.
+
+class RuboCop::RSpec::Language::SelectorSet
+  def each(&blk)
+    selectors.each(&blk)
+  end
+end

--- a/lib/rubocop/rspec/language/each_selector.rb
+++ b/lib/rubocop/rspec/language/each_selector.rb
@@ -1,7 +1,13 @@
 # Monkey-patch SelectorSet to allow enumeration of selectors.
 
-class RuboCop::RSpec::Language::SelectorSet
-  def each(&blk)
-    selectors.each(&blk)
+module RuboCop
+  module RSpec
+    module Language
+      class SelectorSet
+        def each(&blk)
+          selectors.each(&blk)
+        end
+      end
+    end
   end
 end

--- a/lib/salsify_rubocop.rb
+++ b/lib/salsify_rubocop.rb
@@ -14,3 +14,4 @@ RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
 
 # cops
 require 'rubocop/cop/salsify/rspec_doc_string'
+require 'rubocop/cop/salsify/rspec_string_literals'

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SalsifyRubocop
-  VERSION = '0.42.0'.freeze
+  VERSION = '0.43.0'.freeze
 end

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.42.0'
-  spec.add_runtime_dependency 'rubocop-rspec', '~> 1.5.1'
+  spec.add_runtime_dependency 'rubocop', '~> 0.43.0'
+  spec.add_runtime_dependency 'rubocop-rspec', '~> 1.7.0'
 end

--- a/spec/rubocop/cop/salsify/rspec_doc_string_spec.rb
+++ b/spec/rubocop/cop/salsify/rspec_doc_string_spec.rb
@@ -1,4 +1,5 @@
 # encoding utf-8
+# frozen_string_literal: true
 
 describe RuboCop::Cop::Salsify::RspecDocString, :config do
   subject(:cop) { described_class.new(config) }
@@ -68,6 +69,8 @@ describe RuboCop::Cop::Salsify::RspecDocString, :config do
                        ])
         expect(cop.offenses).to be_empty
       end
+
+      it_behaves_like 'always accepted strings', name
     end
   end
 end

--- a/spec/rubocop/cop/salsify/rspec_doc_string_spec.rb
+++ b/spec/rubocop/cop/salsify/rspec_doc_string_spec.rb
@@ -4,7 +4,7 @@
 describe RuboCop::Cop::Salsify::RspecDocString, :config do
   subject(:cop) { described_class.new(config) }
 
-  shared_examples_for 'always accepted strings' do |name|
+  shared_examples_for "always accepted strings" do |name|
     it "accepts `#{name}` with a single character" do
       inspect_source(cop, ["#{name} ?a do", 'end'])
       expect(cop.offenses).to be_empty
@@ -44,7 +44,7 @@ describe RuboCop::Cop::Salsify::RspecDocString, :config do
         expect(cop.offenses).to be_empty
       end
 
-      it_behaves_like 'always accepted strings', name
+      it_behaves_like "always accepted strings", name
     end
   end
 
@@ -70,7 +70,7 @@ describe RuboCop::Cop::Salsify::RspecDocString, :config do
         expect(cop.offenses).to be_empty
       end
 
-      it_behaves_like 'always accepted strings', name
+      it_behaves_like "always accepted strings", name
     end
   end
 end

--- a/spec/rubocop/cop/salsify/rspec_string_literals_spec.rb
+++ b/spec/rubocop/cop/salsify/rspec_string_literals_spec.rb
@@ -4,7 +4,7 @@
 describe RuboCop::Cop::Salsify::RspecStringLiterals, :config do
   subject(:cop) { described_class.new(config) }
 
-  shared_examples_for 'string quoting exceptions' do |name|
+  shared_examples_for "string quoting exceptions" do |name|
     it "accepts `#{name}` with a single character" do
       inspect_source(cop, ["#{name} 'ignored' do", '?a', 'end'])
       expect(cop.offenses).to be_empty
@@ -42,7 +42,7 @@ describe RuboCop::Cop::Salsify::RspecStringLiterals, :config do
           expect(cop.offenses).to be_empty
         end
 
-        it_behaves_like 'string quoting exceptions', name
+        it_behaves_like "string quoting exceptions", name
       end
     end
   end
@@ -67,7 +67,7 @@ describe RuboCop::Cop::Salsify::RspecStringLiterals, :config do
           expect(cop.offenses).to be_empty
         end
 
-        it_behaves_like 'string quoting exceptions', name
+        it_behaves_like "string quoting exceptions", name
       end
     end
   end

--- a/spec/rubocop/cop/salsify/rspec_string_literals_spec.rb
+++ b/spec/rubocop/cop/salsify/rspec_string_literals_spec.rb
@@ -6,18 +6,18 @@ describe RuboCop::Cop::Salsify::RspecStringLiterals, :config do
 
   shared_examples_for 'string quoting exceptions' do |name|
     it "accepts `#{name}` with a single character" do
-      inspect_source(cop, ["#{name} 'ignored' do", "?a", 'end'])
+      inspect_source(cop, ["#{name} 'ignored' do", '?a', 'end'])
       expect(cop.offenses).to be_empty
     end
 
     it "accepts `#{name}` with a %q string" do
-      inspect_source(cop, ["#{name} 'ignored' do", "%q(doc string)", 'end'])
+      inspect_source(cop, ["#{name} 'ignored' do", '%q(doc string)', 'end'])
       expect(cop.offenses).to be_empty
     end
 
     it "accepts `#{name}` with a string the requires interpolation" do
       doc_string = '"#{\'DOC\'.downcase} string"'
-      inspect_source(cop, ["#{name} 'ignored' do", "#{doc_string}", 'end'])
+      inspect_source(cop, ["#{name} 'ignored' do", doc_string, 'end'])
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/salsify/rspec_string_literals_spec.rb
+++ b/spec/rubocop/cop/salsify/rspec_string_literals_spec.rb
@@ -1,0 +1,74 @@
+# encoding utf-8
+# frozen_string_literal: true
+
+describe RuboCop::Cop::Salsify::RspecStringLiterals, :config do
+  subject(:cop) { described_class.new(config) }
+
+  shared_examples_for 'string quoting exceptions' do |name|
+    it "accepts `#{name}` with a single character" do
+      inspect_source(cop, ["#{name} 'ignored' do", "?a", 'end'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it "accepts `#{name}` with a %q string" do
+      inspect_source(cop, ["#{name} 'ignored' do", "%q(doc string)", 'end'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it "accepts `#{name}` with a string the requires interpolation" do
+      doc_string = '"#{\'DOC\'.downcase} string"'
+      inspect_source(cop, ["#{name} 'ignored' do", "#{doc_string}", 'end'])
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  context "when the enforced style is `single_quotes` (default)" do
+    let(:cop_config) { { 'EnforcedStyle' => 'single_quotes' } }
+
+    described_class::DOCUMENTED_METHODS.each do |name|
+      context "within #{name}" do
+        it "corrects a double-quoted string" do
+          source = ["#{name} \"doc string\" do", '"literal"', 'end']
+          inspect_source(cop, source)
+          expect(cop.messages).to eq([described_class::SINGLE_QUOTE_MSG])
+          expect(cop.highlights).to eq([source[1]])
+          expect(autocorrect_source(cop, source))
+            .to eq("#{name} \"doc string\" do\n'literal'\nend")
+        end
+
+        it "accepts a single-quoted string" do
+          source = ["#{name} 'doc string' do", "'literal'", 'end']
+          inspect_source(cop, source)
+          expect(cop.offenses).to be_empty
+        end
+
+        it_behaves_like 'string quoting exceptions', name
+      end
+    end
+  end
+
+  context "when the enforced style is `double_quotes`" do
+    let(:cop_config) { { 'EnforcedStyle' => 'double_quotes' } }
+
+    described_class::DOCUMENTED_METHODS.each do |name|
+      context "within #{name}" do
+        it "corrects a single-quoted string" do
+          source = ["#{name} 'doc string' do", "'literal'", 'end']
+          inspect_source(cop, source)
+          expect(cop.messages).to eq([described_class::DOUBLE_QUOTE_MSG])
+          expect(cop.highlights).to eq([source[1]])
+          expect(autocorrect_source(cop, source))
+            .to eq("#{name} 'doc string' do\n\"literal\"\nend")
+        end
+
+        it "accepts a double-quoted string" do
+          source = ["#{name} \"doc string\" do", '"literal"', 'end']
+          inspect_source(cop, source)
+          expect(cop.offenses).to be_empty
+        end
+
+        it_behaves_like 'string quoting exceptions', name
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,3 +2,4 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'salsify_rubocop'
 
 require 'rubocop/rspec/support'
+require 'rubocop/rspec/language/each_selector'


### PR DESCRIPTION
Repeated from the CHANGELOG:
- Update to `rubocop` v0.43.0.
- Update to `rubocop-rspec` v1.7.0.
- Disable new RSpec cops: `LeadingSubject`, `LetSetup`, `MultipleExpectations`,
  and `NestedGroups`.
- Disable new cop `RSpec/ExpectActual` for routing specs.
- Disable problematic cops `Style/NumericPredicate`, `Style/SafeNavigation`,
  and `Style/VariableNumber`.
- Disable `Style/IndentHash`, which applies to the first line, since we are not
  using `Style/AlignHash`.
- Add `Salsify/RspecStringLiterals` cop to check non-doc string quotes for
  examples/example groups.

Previously, I included the actual config file changes in the CHANGELOG. If we prefer that style, I can swap that for what is here.

Prime: @jturkel 
