### PR TITLE
Update to rubocop v0.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # salsify_rubocop
 
+## v0.44.0
+- Update to `rubocop` v0.44.1.
+- Disable new RSpec cops: `Metrics/BlockLength` and
+  `Rails/HttpPositionalArguments`.
+
 ## v0.43.0
 - Update to `rubocop` v0.43.0.
 - Update to `rubocop-rspec` v1.7.0.

--- a/conf/rubocop_rails.yml
+++ b/conf/rubocop_rails.yml
@@ -4,6 +4,10 @@ inherit_from:
 Rails:
   Enabled: true
 
+# Enforces Rails 5 conventions. Auto-correct removes parens around args :(
+Rails/HttpPositionalArguments:
+  Enabled: false
+
 Rails/TimeZone:
   Exclude:
     - 'spec/**/*'

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -116,6 +116,9 @@ Style/VariableNumber:
 Metrics/AbcSize:
   Enabled: false
 
+Metrics/BlockLength:
+  Enabled: false
+
 Metrics/BlockNesting:
   Enabled: false
 

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SalsifyRubocop
-  VERSION = '0.43.0'.freeze
+  VERSION = '0.44.0'.freeze
 end

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.43.0'
+  spec.add_runtime_dependency 'rubocop', '~> 0.44.1'
   spec.add_runtime_dependency 'rubocop-rspec', '~> 1.7.0'
 end


### PR DESCRIPTION
I think the main thing we'll find useful in the latest rubocop is `Rails/DynamicFindBy`, enforcing `find_by(x: ...)` instead of `find_by_x(...)`.

https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0440-2016-10-13

Prime: @jturkel 
