### PR TITLE
Update to rubocop v0.46.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
-  - 2.2.4
-  - 2.3.1
+  - 2.3.3
 script:
   - bundle exec rubocop
   - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - 2.2.4
   - 2.3.3
 script:
   - bundle exec rubocop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # salsify_rubocop
 
+## v0.46.0
+- Update to `rubocop` v0.46.0.
+- Disable new cops: `Bundler/OrderedGems` and `Style/EmptyMethod`.
+- Disable cops: `Style/MultilineBlockChain` and `Style/SingleLineBlockParams`.
+
 ## v0.45.0
 - Update to `rubocop` v0.45.0 and `rubocop-rspec` v1.8.0.
 - Explicitly enable `Rspec/MessageExpectation` cop that is now disabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # salsify_rubocop
 
+# TODO: revisit Bundler/OrderedGems when auto-correct is available.
+
 ## v0.46.0
 - Update to `rubocop` v0.46.0.
 - Disable new cops: `Bundler/OrderedGems` and `Style/EmptyMethod`.

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -8,6 +8,9 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
 
+Bundler/OrderedGems:
+  Enabled: false
+
 Lint/AmbiguousOperator:
   Enabled: false
 
@@ -52,6 +55,9 @@ Style/EmptyLinesAroundMethodBody:
 Style/EmptyLiteral:
   Enabled: false
 
+Style/EmptyMethod:
+  Enabled: false
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 
@@ -67,6 +73,9 @@ Style/Lambda:
 
 Style/ModuleFunction:
   EnforcedStyle: extend_self
+
+Style/MultilineBlockChain:
+  Enabled: false
 
 Style/MultilineMethodCallIndentation:
   Enabled: false
@@ -97,13 +106,16 @@ Style/RegexpLiteral:
 Style/SafeNavigation:
   Enabled: false
 
+Style/SignalException:
+  EnforcedStyle: only_raise
+
+Style/SingleLineBlockParams:
+  Enabled: false
+
 # This cop doesn't work properly if you a have a block with
 # arguments split across multiple lines
 Style/SpaceAroundBlockParameters:
   Enabled: false
-
-Style/SignalException:
-  EnforcedStyle: only_raise
 
 Style/StringLiterals:
   EnforcedStyle: single_quotes

--- a/lib/rubocop/cop/salsify/rspec_doc_string.rb
+++ b/lib/rubocop/cop/salsify/rspec_doc_string.rb
@@ -26,9 +26,9 @@ module RuboCop
         include ConfigurableEnforcedStyle
 
         SINGLE_QUOTE_MSG =
-          'Example Group/Example doc strings must be single-quoted.'.freeze
+          'Example Group/Example doc strings must be single-quoted.'
         DOUBLE_QUOTE_MSG =
-          'Example Group/Example doc strings must be double-quoted.'.freeze
+          'Example Group/Example doc strings must be double-quoted.'
 
         SHARED_EXAMPLES = RuboCop::RSpec::Language::SelectorSet.new(
           %i(include_examples it_behaves_like it_should_behave_like include_context)

--- a/lib/rubocop/cop/salsify/rspec_doc_string.rb
+++ b/lib/rubocop/cop/salsify/rspec_doc_string.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-# frozen_string_literal: true
 
 module RuboCop
   module Cop
@@ -26,9 +25,9 @@ module RuboCop
         include ConfigurableEnforcedStyle
 
         SINGLE_QUOTE_MSG =
-          'Example Group/Example doc strings must be single-quoted.'
+          'Example Group/Example doc strings must be single-quoted.'.freeze
         DOUBLE_QUOTE_MSG =
-          'Example Group/Example doc strings must be double-quoted.'
+          'Example Group/Example doc strings must be double-quoted.'.freeze
 
         SHARED_EXAMPLES = RuboCop::RSpec::Language::SelectorSet.new(
           %i(include_examples it_behaves_like it_should_behave_like include_context)

--- a/lib/rubocop/cop/salsify/rspec_string_literals.rb
+++ b/lib/rubocop/cop/salsify/rspec_string_literals.rb
@@ -19,9 +19,9 @@ module RuboCop
         DOCUMENTED_METHODS = RuboCop::Cop::Salsify::RspecDocString::DOCUMENTED_METHODS
 
         SINGLE_QUOTE_MSG = 'Prefer single-quoted strings unless you need ' \
-          'interpolation or special symbols.'.freeze
+          'interpolation or special symbols.'
         DOUBLE_QUOTE_MSG = 'Prefer double-quoted strings unless you need ' \
-          'single quotes to avoid extra backslashes for escaping.'.freeze
+          'single quotes to avoid extra backslashes for escaping.'
 
         private
 

--- a/lib/rubocop/cop/salsify/rspec_string_literals.rb
+++ b/lib/rubocop/cop/salsify/rspec_string_literals.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-# frozen_string_literal: true
 
 module RuboCop
   module Cop
@@ -19,9 +18,9 @@ module RuboCop
         DOCUMENTED_METHODS = RuboCop::Cop::Salsify::RspecDocString::DOCUMENTED_METHODS
 
         SINGLE_QUOTE_MSG = 'Prefer single-quoted strings unless you need ' \
-          'interpolation or special symbols.'
+          'interpolation or special symbols.'.freeze
         DOUBLE_QUOTE_MSG = 'Prefer double-quoted strings unless you need ' \
-          'single quotes to avoid extra backslashes for escaping.'
+          'single quotes to avoid extra backslashes for escaping.'.freeze
 
         private
 

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SalsifyRubocop
-  VERSION = '0.45.0'.freeze
+  VERSION = '0.46.0'.freeze
 end

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.45.0'
+  spec.add_runtime_dependency 'rubocop', '~> 0.46.0'
   spec.add_runtime_dependency 'rubocop-rspec', '~> 1.8.0'
 end


### PR DESCRIPTION
Not a big update this time: https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0460-2016-11-30

A couple of the new cops don't seem worthy enforcing for us. And a couple of existing cops were annoying and are now disabled.

Prime: @jturkel 