### PR TITLE
Update to rubocop v0.47.1 and rubocop-rspec v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # salsify_rubocop
 
-# TODO: revisit Bundler/OrderedGems when auto-correct is available.
+## v0.47.0
+- Update to `rubocop` v0.47.1 and `rubocop-rspec` v1.10.0.
+- Enable `Bundler/OrderedGems` now that auto-correct is supported.
+- Disable new cop `Rails/FilePath`.
+- Add `DisplayCopNames: true` default for `AllCops`.
 
 ## v0.46.0
 - Update to `rubocop` v0.46.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Update to `rubocop` v0.47.1 and `rubocop-rspec` v1.10.0.
 - Enable `Bundler/OrderedGems` now that auto-correct is supported.
 - Disable new cop `Rails/FilePath`.
+- Disable `RSpec/MessageExpectation` and use `RSpec/MessageSpies` instead.
 - Add `DisplayCopNames: true` default for `AllCops`.
 
 ## v0.46.0

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -29,9 +29,6 @@ RSpec/LeadingSubject:
 RSpec/LetSetup:
   Enabled: false
 
-RSpec/MessageExpectation:
-  Enabled: true
-
 RSpec/MultipleExpectations:
   Enabled: false
 

--- a/conf/rubocop_rails.yml
+++ b/conf/rubocop_rails.yml
@@ -4,6 +4,9 @@ inherit_from:
 Rails:
   Enabled: true
 
+Rails/FilePath:
+  Enabled: false
+
 # Enforces Rails 5 conventions. Auto-correct removes parens around args :(
 Rails/HttpPositionalArguments:
   Enabled: false
@@ -13,4 +16,4 @@ Rails/TimeZone:
     - 'spec/**/*'
 
 Rails/UniqBeforePluck:
-  EnforcedMode: aggressive
+  EnforcedStyle: aggressive

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -1,4 +1,5 @@
 AllCops:
+  DisplayCopNames: true
   Exclude:
     - 'bin/**/*'
     - 'coverage/**/*'
@@ -7,9 +8,6 @@ AllCops:
     - 'public/**/*'
     - 'tmp/**/*'
     - 'vendor/**/*'
-
-Bundler/OrderedGems:
-  Enabled: false
 
 Lint/AmbiguousOperator:
   Enabled: false

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SalsifyRubocop
-  VERSION = '0.46.0'.freeze
+  VERSION = '0.47.0'.freeze
 end

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.46.0'
-  spec.add_runtime_dependency 'rubocop-rspec', '~> 1.8.0'
+  spec.add_runtime_dependency 'rubocop', '~> 0.47.1'
+  spec.add_runtime_dependency 'rubocop-rspec', '~> 1.10.0'
 end


### PR DESCRIPTION
I tested this version against several services and gems (excluding dandelion) and there are no major differences in the offenses detected.

- rubocop v0.47.1 changes: https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0471-2017-01-18
- rubocop-rspec v1.10.0 changes: https://github.com/backus/rubocop-rspec/blob/master/CHANGELOG.md#1100-2017-01-15

Prime: @will89 