### PR TITLE
Add custom cop Salsify/StyleDig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # salsify_rubocop
 
+## v0.47.1
+- Add `Salsify/StyleDig` cop to recommend using `#dig` for deeply nested access.
+
 ## v0.47.0
 - Update to `rubocop` v0.47.1 and `rubocop-rspec` v1.10.0.
 - Enable `Bundler/OrderedGems` now that auto-correct is supported.

--- a/config/default.yml
+++ b/config/default.yml
@@ -18,3 +18,8 @@ Salsify/RspecStringLiterals:
 #  Include:
 #    - 'spec/**/*'
 
+Salsify/StyleDig:
+  Description: 'Recommend `dig` for deeply nested access.'
+  Enabled: true
+  AutoCorrect: false
+

--- a/lib/rubocop/cop/salsify/rspec_doc_string.rb
+++ b/lib/rubocop/cop/salsify/rspec_doc_string.rb
@@ -6,8 +6,6 @@ module RuboCop
       # Check that doc strings for example groups and examples use either
       # single-quoted or double-quoted strings based on the enforced style.
       #
-      # This cop is disabled by default.
-      #
       # @example
       #
       #   # When EnforcedStyle is double_quotes

--- a/lib/rubocop/cop/salsify/style_dig.rb
+++ b/lib/rubocop/cop/salsify/style_dig.rb
@@ -1,0 +1,64 @@
+# encoding: utf-8
+
+module RuboCop
+  module Cop
+    module Salsify
+      # Use `dig` for deeply nested access.
+      #
+      # @example
+      #
+      #   # good
+      #   my_hash.dig('foo', 'bar')
+      #   my_array.dig(0, 1)
+      #
+      #   # bad
+      #   my_hash['foo']['bar']
+      #   my_hash['foo'] && my_hash['foo']['bar']
+      #   my_array[0][1]
+
+      class StyleDig < Cop
+        extend TargetRubyVersion
+
+        minimum_target_ruby_version 2.3
+
+        MSG = 'Use `dig` for nested access.'.freeze
+
+        def_node_matcher :nested_access_match, <<-PATTERN
+          (send (send (send _receiver !:[]) :[] _) :[] _)
+        PATTERN
+
+        def on_send(node)
+          nested_access_match(node) do
+            match_node = node
+            # walk to outermost access node
+            match_node = match_node.parent while access_node?(match_node.parent)
+            add_offense(match_node, :expression, MSG)
+          end
+        end
+
+        def autocorrect(node)
+          access_node = node
+          source_args = [access_node.method_args.first.source]
+          while access_node?(access_node.children.first)
+            access_node = access_node.children.first
+            source_args << access_node.method_args.first.source
+          end
+          root_node = access_node.children.first
+
+          lambda do |corrector|
+            range = Parser::Source::Range.new(node.source_range.source_buffer,
+                                              root_node.source_range.end_pos,
+                                              node.source_range.end_pos)
+            corrector.replace(range, ".dig(#{source_args.reverse.join(', ')})")
+          end
+        end
+
+        private
+
+        def access_node?(node)
+          node && node.send_type? && node.method_name == :[]
+        end
+      end
+    end
+  end
+end

--- a/lib/salsify_rubocop.rb
+++ b/lib/salsify_rubocop.rb
@@ -15,3 +15,4 @@ RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
 # cops
 require 'rubocop/cop/salsify/rspec_doc_string'
 require 'rubocop/cop/salsify/rspec_string_literals'
+require 'rubocop/cop/salsify/style_dig'

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SalsifyRubocop
-  VERSION = '0.47.0'.freeze
+  VERSION = '0.47.1.rc0'.freeze
 end

--- a/spec/rubocop/cop/salsify/style_dig_spec.rb
+++ b/spec/rubocop/cop/salsify/style_dig_spec.rb
@@ -1,0 +1,53 @@
+# encoding utf-8
+# frozen_string_literal: true
+
+describe RuboCop::Cop::Salsify::StyleDig, :config, :ruby23 do
+  subject(:cop) { described_class.new(config) }
+  let(:msgs) { [described_class::MSG] }
+
+  it "accepts non-nested access" do
+    source = 'ary[0]'
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it "corrects nested access" do
+    source = 'hash[one][two]'
+    inspect_source(cop, source)
+    expect(cop.highlights).to eq([source])
+    expect(cop.messages).to eq(msgs)
+    expect(autocorrect_source(cop, source)).to eq('hash.dig(one, two)')
+  end
+
+  it "corrects triple-nested access" do
+    source = 'hash[one][two][three]'
+    inspect_source(cop, source)
+    expect(cop.highlights).to eq([source])
+    expect(cop.messages).to eq(msgs)
+    expect(autocorrect_source(cop, source)).to eq('hash.dig(one, two, three)')
+  end
+
+  it "corrects nested access after a method call" do
+    source = 'obj.hash[:one][:two]'
+    inspect_source(cop, source)
+    expect(cop.highlights).to eq([source])
+    expect(cop.messages).to eq(msgs)
+    expect(autocorrect_source(cop, source)).to eq('obj.hash.dig(:one, :two)')
+  end
+
+  it "corrects nested access for a method arg" do
+    source = 'call(array[0][1])'
+    inspect_source(cop, source)
+    expect(cop.highlights).to eq(['array[0][1]'])
+    expect(cop.messages).to eq(msgs)
+    expect(autocorrect_source(cop, source)).to eq('call(array.dig(0, 1))')
+  end
+
+  it "corrects when a method is called after nested access" do
+    source = 'hash[one][two].foo'
+    inspect_source(cop, source)
+    expect(cop.highlights).to eq(['hash[one][two]'])
+    expect(cop.messages).to eq(msgs)
+    expect(autocorrect_source(cop, source)).to eq('hash.dig(one, two).foo')
+  end
+end


### PR DESCRIPTION
This cop flags where it may be possible to use `#dig` with ruby 2.3 and later.

Auto-correct is disabled by default for this cop because it may identify false positives, but it is implemented here because it was useful for the initial application to a project (see forthcoming PR for Dandelion).

Prime: @jturkel 