### PR TITLE
Add Salsify/RailsApplicationRecord cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # salsify_rubocop
 
+## v0.47.1
+- Add new `Salsify/RailsApplicationRecord` cop.
+- Add new `rubocop_rails50` configuration for use with Rails 5.0 apps.
+
 ## v0.47.0
 - Update to `rubocop` v0.47.1 and `rubocop-rspec` v1.10.0.
 - Enable `Bundler/OrderedGems` now that auto-correct is supported.

--- a/conf/rubocop_rails50.yml
+++ b/conf/rubocop_rails50.yml
@@ -1,0 +1,8 @@
+inherit_from:
+  - ../conf/rubocop_rails.yml
+
+Rails/HttpPositionalArguments:
+  Enabled: true
+
+Salsify/RailsApplicationRecord:
+  Enabled: true

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,3 +1,7 @@
+Salsify/RailsApplicationRecord:
+  Description: 'Models must subclass ApplicationRecord.'
+  Enabled: false
+
 Salsify/RspecDocString:
   Description: 'Check that RSpec doc strings use the correct quoting.'
   Enabled: true

--- a/lib/rubocop/cop/salsify/rails_application_record.rb
+++ b/lib/rubocop/cop/salsify/rails_application_record.rb
@@ -1,0 +1,53 @@
+# encoding: utf-8
+require 'rubocop'
+module RuboCop
+  module Cop
+    module Salsify
+      # Check that models subclass ApplicationRecord with Rails 5.0
+      #
+      # @example
+      #
+      #  # good
+      #  class Tesla < ApplicationRecord
+      #    ...
+      #  end
+      #
+      #  # bad
+      #  class Yugo < ActiveRecord::Base
+      #    ...
+      #  end
+      class RailsApplicationRecord < Cop
+
+        MSG = 'Models must subclass ApplicationRecord'.freeze
+        APPLICATION_RECORD = 'ApplicationRecord'.freeze
+        ACTIVE_RECORD_BASE_PATTERN = '(const (const nil :ActiveRecord) :Base)'.freeze
+
+        def_node_matcher :model_class_definition, <<-PATTERN
+        (class (const _ !:ApplicationRecord) #{ACTIVE_RECORD_BASE_PATTERN} ...)
+        PATTERN
+
+        def_node_matcher :class_new_definition, <<-PATTERN
+        [!^(casgn nil :ApplicationRecord ...) (send (const nil :Class) :new #{ACTIVE_RECORD_BASE_PATTERN})]
+        PATTERN
+
+        def on_class(node)
+          model_class_definition(node) do
+            add_offense(node.children[1], :expression, MSG)
+          end
+        end
+
+        def on_send(node)
+          class_new_definition(node) do
+            add_offense(node.children.last, :expression, MSG)
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(node.source_range, APPLICATION_RECORD)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/salsify_rubocop.rb
+++ b/lib/salsify_rubocop.rb
@@ -13,5 +13,6 @@ config = RuboCop::ConfigLoader.merge_with_default(config, path)
 RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
 
 # cops
+require 'rubocop/cop/salsify/rails_application_record'
 require 'rubocop/cop/salsify/rspec_doc_string'
 require 'rubocop/cop/salsify/rspec_string_literals'

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SalsifyRubocop
-  VERSION = '0.47.0'.freeze
+  VERSION = '0.47.1'.freeze
 end

--- a/spec/rubocop/cop/salsify/rails_application_record_spec.rb
+++ b/spec/rubocop/cop/salsify/rails_application_record_spec.rb
@@ -1,0 +1,75 @@
+# encoding utf-8
+# frozen_string_literal: true
+
+describe RuboCop::Cop::Salsify::RailsApplicationRecord, :config do
+  subject(:cop) { described_class.new(config) }
+  let(:msgs) { [described_class::MSG] }
+
+  it "allows ApplicationRecord to be defined" do
+    source = "class ApplicationRecord < ActiveRecord::Base\nend"
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it "corrects models that subclass ActiveRecord::Base" do
+    source = "class MyModel < ActiveRecord::Base\nend"
+    inspect_source(cop, source)
+    expect(cop.messages).to eq(msgs)
+    expect(cop.highlights).to eq(['ActiveRecord::Base'])
+    expect(autocorrect_source(cop, source)).to eq("class MyModel < ApplicationRecord\nend")
+  end
+
+  it "corrects single-line class definitions" do
+    source = 'class MyModel < ActiveRecord::Base; end'
+    inspect_source(cop, source)
+    expect(cop.messages).to eq(msgs)
+    expect(cop.highlights).to eq(['ActiveRecord::Base'])
+    expect(autocorrect_source(cop, source)).to eq('class MyModel < ApplicationRecord; end')
+  end
+
+  it "corrects namespaced models that subclass ActiveRecord::Base" do
+    source = "module Nested\n  class MyModel < ActiveRecord::Base\n  end\nend"
+    inspect_source(cop, source)
+    expect(cop.messages).to eq(msgs)
+    expect(cop.highlights).to eq(['ActiveRecord::Base'])
+    expect(autocorrect_source(cop, source)).to eq("module Nested\n  class MyModel < ApplicationRecord\n  end\nend")
+  end
+
+  it "corrects models defined using nested constants" do
+    source = "class Nested::MyModel < ActiveRecord::Base\nend"
+    inspect_source(cop, source)
+    expect(cop.messages).to eq(msgs)
+    expect(cop.highlights).to eq(['ActiveRecord::Base'])
+    expect(autocorrect_source(cop, source)).to eq("class Nested::MyModel < ApplicationRecord\nend")
+  end
+
+  it "corrects models defined using Class.new" do
+    source = 'MyModel = Class.new(ActiveRecord::Base)'
+    inspect_source(cop, source)
+    expect(cop.messages).to eq(msgs)
+    expect(cop.highlights).to eq(['ActiveRecord::Base'])
+    expect(autocorrect_source(cop, source)).to eq('MyModel = Class.new(ApplicationRecord)')
+  end
+
+  it "corrects nested models defined using Class.new" do
+    source = 'Nested::MyModel = Class.new(ActiveRecord::Base)'
+    inspect_source(cop, source)
+    expect(cop.messages).to eq(msgs)
+    expect(cop.highlights).to eq(['ActiveRecord::Base'])
+    expect(autocorrect_source(cop, source)).to eq('Nested::MyModel = Class.new(ApplicationRecord)')
+  end
+
+  it "correct anonymous models" do
+    source = 'Class.new(ActiveRecord::Base) {}'
+    inspect_source(cop, source)
+    expect(cop.messages).to eq(msgs)
+    expect(cop.highlights).to eq(['ActiveRecord::Base'])
+    expect(autocorrect_source(cop, source)).to eq('Class.new(ApplicationRecord) {}')
+  end
+
+  it "allows ApplicationRecord defined using Class.new" do
+    source = 'ApplicationRecord = Class.new(ActiveRecord::Base)'
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
+  end
+end


### PR DESCRIPTION
If we're using Rails 5.0 and `ApplicationRecord` then we should have a way to enforce that `ApplicationRecord` is used.

This will conflict with https://github.com/salsify/salsify_rubocop/pull/12 if both are approved. In that eventually, I'll deal with reconciling them.

Prime: @jturkel 