### PR TITLE
Dependency updates and new cop RspecDotNotSelfDot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # salsify_rubocop
 
+## v0.48.0
+- Add `Salsify/RspecDotNotSelfDot` cop.
+
 ## v0.47.2
 - Fix issue for `Salsify/Style` with nested access as the target for
   conditional assignment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.48.0
 - Add `Salsify/RspecDotNotSelfDot` cop.
+- Update to `rubocop` v0.48.1 and `rubocop-rspec` v1.15.0.
+- Disable cops: `Lint/AmbiguousBlockAssociation`, `Style/PercentLiteralDelimiters`,
+  and `Style/SymbolArray`.
 
 ## v0.47.2
 - Fix issue for `Salsify/Style` with nested access as the target for

--- a/conf/rubocop_rails50.yml
+++ b/conf/rubocop_rails50.yml
@@ -1,6 +1,9 @@
 inherit_from:
   - ../conf/rubocop_rails.yml
 
+AllCops:
+  TargetRailsVersion: 5.0
+
 Rails/HttpPositionalArguments:
   Enabled: true
 

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -9,6 +9,10 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
 
+# This cop has poor handling for the common case of a lambda arg in a DSL
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+
 Lint/AmbiguousOperator:
   Enabled: false
 
@@ -56,6 +60,12 @@ Style/EmptyLiteral:
 Style/EmptyMethod:
   Enabled: false
 
+# The Exclude list is not additive. Projects that exclude file names will
+# need to re-add Appraisals.
+Style/FileName:
+  Exclude:
+    - 'Appraisals'
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 
@@ -92,6 +102,10 @@ Style/NumericLiteralPrefix:
 Style/NumericPredicate:
   Enabled: false
 
+# This cop is unstable.
+Style/PercentLiteralDelimiters:
+  Enabled: false
+
 Style/Proc:
   Enabled: false
 
@@ -119,6 +133,10 @@ Style/StringLiterals:
   EnforcedStyle: single_quotes
   Exclude:
     - 'spec/**/*'
+
+# We don't require %i() for an array of symbols.
+Style/SymbolArray:
+  Enabled: false
 
 Style/VariableNumber:
   Enabled: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -12,6 +12,12 @@ Salsify/RspecDocString:
   Include:
     - 'spec/**/*'
 
+Salsify/RspecDotNotSelfDot:
+  Description: 'Enforce ".<class method>" instead of "self.<class method>" for example group description.'
+  Enabled: true
+  Include:
+    - 'spec/**/*'
+
 Salsify/RspecStringLiterals:
   Description: 'Enforce consistent quote style for non-doc strings in RSpec tests.'
   Enabled: true
@@ -19,8 +25,8 @@ Salsify/RspecStringLiterals:
   SupportedStyles:
     - single_quotes
     - double_quotes
-#  Include:
-#    - 'spec/**/*'
+  Include:
+    - 'spec/**/*'
 
 Salsify/StyleDig:
   Description: 'Recommend `dig` for deeply nested access.'

--- a/lib/rubocop/cop/salsify/rails_application_record.rb
+++ b/lib/rubocop/cop/salsify/rails_application_record.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
+
 require 'rubocop'
+
 module RuboCop
   module Cop
     module Salsify

--- a/lib/rubocop/cop/salsify/rspec_doc_string.rb
+++ b/lib/rubocop/cop/salsify/rspec_doc_string.rb
@@ -60,7 +60,7 @@ module RuboCop
           src = node.source
           return false if src.start_with?('%', '?')
           if style == :single_quotes
-            src !~ /^'/ && !double_quotes_acceptable?(node.str_content)
+            src !~ /^'/ && !needs_escaping?(node.str_content)
           else
             src !~ /^" | \\ | \#/x
           end

--- a/lib/rubocop/cop/salsify/rspec_dot_not_self_dot.rb
+++ b/lib/rubocop/cop/salsify/rspec_dot_not_self_dot.rb
@@ -1,0 +1,45 @@
+# encoding: utf-8
+
+module RuboCop
+  module Cop
+    module Salsify
+      # Use ".<class method>" instead of "self.<class method>" in RSpec example
+      # group descriptions.
+      #
+      # @example
+      #
+      #   # good
+      #   describe ".does_stuff" do
+      #     ...
+      #   end
+      #
+      #   # bad
+      #   describe "self.does_stuff" do
+      #     ...
+      #   end
+      class RspecDotNotSelfDot < Cop
+
+        SELF_DOT_REGEXP = /["']self\./
+        MSG = 'Use ".<class method>" instead of "self.<class method>" for example group description.'.freeze
+
+        def_node_matcher :example_group_match, <<-PATTERN
+          (send _ #{RuboCop::RSpec::Language::ExampleGroups::ALL.node_pattern_union} $_ ...)
+        PATTERN
+
+        def on_send(node)
+          example_group_match(node) do |doc|
+            add_offense(doc, :expression, MSG) if SELF_DOT_REGEXP =~ doc.source
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.remove(Parser::Source::Range.new(node.source_range.source_buffer,
+                                                       node.source_range.begin_pos + 1,
+                                                       node.source_range.begin_pos + 5))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/salsify_rubocop.rb
+++ b/lib/salsify_rubocop.rb
@@ -15,5 +15,6 @@ RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
 # cops
 require 'rubocop/cop/salsify/rails_application_record'
 require 'rubocop/cop/salsify/rspec_doc_string'
+require 'rubocop/cop/salsify/rspec_dot_not_self_dot'
 require 'rubocop/cop/salsify/rspec_string_literals'
 require 'rubocop/cop/salsify/style_dig'

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SalsifyRubocop
-  VERSION = '0.47.2'.freeze
+  VERSION = '0.48.0'.freeze
 end

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'salsify_rubocop/version'
@@ -33,6 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.47.1'
-  spec.add_runtime_dependency 'rubocop-rspec', '~> 1.10.0'
+  spec.add_runtime_dependency 'rubocop', '~> 0.48.1'
+  spec.add_runtime_dependency 'rubocop-rspec', '~> 1.15.0'
 end

--- a/spec/rubocop/cop/salsify/rails_application_record_spec.rb
+++ b/spec/rubocop/cop/salsify/rails_application_record_spec.rb
@@ -2,8 +2,9 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Salsify::RailsApplicationRecord, :config do
-  subject(:cop) { described_class.new(config) }
   let(:msgs) { [described_class::MSG] }
+
+  subject(:cop) { described_class.new(config) }
 
   it "allows ApplicationRecord to be defined" do
     source = "class ApplicationRecord < ActiveRecord::Base\nend"

--- a/spec/rubocop/cop/salsify/rspec_dot_not_self_dot_spec.rb
+++ b/spec/rubocop/cop/salsify/rspec_dot_not_self_dot_spec.rb
@@ -1,0 +1,40 @@
+# encoding utf-8
+# frozen_string_literal: true
+
+describe RuboCop::Cop::Salsify::RspecDotNotSelfDot, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:msgs) { [described_class::MSG] }
+
+  RuboCop::RSpec::Language::ExampleGroups::ALL.each do |name|
+    it "corrects #{name} with `self.class_method`" do
+      source = "#{name} \"self.class_method\" do\nend"
+      inspect_source(cop, source)
+      expect(cop.highlights).to eq(['"self.class_method"'])
+      expect(cop.messages).to eq(msgs)
+      expect(autocorrect_source(cop, source)).to eq(source.sub('self.', '.'))
+    end
+
+    it "corrects #{name} with `self.class_method` and metadata" do
+      source = "#{name} \"self.class_method\", foo: true do\nend"
+      inspect_source(cop, source)
+      expect(cop.highlights).to eq(['"self.class_method"'])
+      expect(cop.messages).to eq(msgs)
+      expect(autocorrect_source(cop, source)).to eq(source.sub('self.', '.'))
+    end
+
+    it "accepts #{name} with `.class_method`" do
+      source = "#{name} \".class_method\" do\nend"
+      inspect_source(cop, source)
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  RuboCop::RSpec::Language::Examples::ALL.each do |name|
+    it "accepts #{name} with `self.class_method`" do
+      source = "#{name} \"self.class_method\" do\nend"
+      inspect_source(cop, source)
+      expect(cop.offenses).to be_empty
+    end
+  end
+end

--- a/spec/rubocop/cop/salsify/rspec_string_literals_spec.rb
+++ b/spec/rubocop/cop/salsify/rspec_string_literals_spec.rb
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Salsify::RspecStringLiterals, :config do
   end
 
   context "when the enforced style is `single_quotes` (default)" do
-    let(:cop_config) { { 'EnforcedStyle' => 'single_quotes' } }
+    let(:cop_config) { { 'EnforcedStyle' => 'single_quotes', 'Include' => ['**/*'] } }
 
     described_class::DOCUMENTED_METHODS.each do |name|
       context "within #{name}" do
@@ -48,7 +48,7 @@ describe RuboCop::Cop::Salsify::RspecStringLiterals, :config do
   end
 
   context "when the enforced style is `double_quotes`" do
-    let(:cop_config) { { 'EnforcedStyle' => 'double_quotes' } }
+    let(:cop_config) { { 'EnforcedStyle' => 'double_quotes', 'Include' => ['**/*'] } }
 
     described_class::DOCUMENTED_METHODS.each do |name|
       context "within #{name}" do

--- a/spec/rubocop/cop/salsify/style_dig_spec.rb
+++ b/spec/rubocop/cop/salsify/style_dig_spec.rb
@@ -2,8 +2,9 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Salsify::StyleDig, :config, :ruby23 do
-  subject(:cop) { described_class.new(config) }
   let(:msgs) { [described_class::MSG] }
+
+  subject(:cop) { described_class.new(config) }
 
   it "accepts non-nested access" do
     source = 'ary[0]'


### PR DESCRIPTION
Lots of new stuff in rubocop as always: https://github.com/bbatsov/rubocop/blob/33cda4978a3576e93d69c301e3a764a9b7e4c0d7/CHANGELOG.md

Most of the changes have little impact ... except on dandelion.

A sizable version bump for rubocop-rspec since I only update when updating the main rubocop, and the releases haven't aligned: https://github.com/backus/rubocop-rspec/blob/954c6129438255123bbe056b07f48e9e2b80b568/CHANGELOG.md

Some of the new cops are pretty opinionated but I'm going with them for now as they haven't generated that many offenses (except in dandelion), and we can continue to tweak configuration.

Prime: @jturkel 
