### PR TITLE
Add cop that checks for ApplicationMailer use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # salsify_rubocop
 
-## v0.49.0
+## v0.48.1
 - Add `Salsify/RailsApplicationMailer` cop.
 
 ## v0.48.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # salsify_rubocop
 
+## v0.49.0
+- Add `Salsify/RailsApplicationMailer` cop.
+
 ## v0.48.0
 - Add `Salsify/RspecDotNotSelfDot` cop.
 - Add `Salsify/RailsApplicationSerializer` cop.

--- a/conf/rubocop_rails50.yml
+++ b/conf/rubocop_rails50.yml
@@ -7,5 +7,8 @@ AllCops:
 Rails/HttpPositionalArguments:
   Enabled: true
 
+Salsify/RailsApplicationMailer:
+  Enabled: true
+
 Salsify/RailsApplicationRecord:
   Enabled: true

--- a/config/default.yml
+++ b/config/default.yml
@@ -3,7 +3,7 @@ Salsify/RailsApplicationSerializer:
   Enabled: false
 
 Salsify/RailsApplicationMailer:
-  Description: 'Models must subclass ApplicationMailer.'
+  Description: 'Mailers must subclass ApplicationMailer.'
   Enabled: false
 
 Salsify/RailsApplicationRecord:

--- a/config/default.yml
+++ b/config/default.yml
@@ -2,6 +2,10 @@ Salsify/RailsApplicationSerializer:
   Description: 'Serializers must subclass ApplicationSerializer.'
   Enabled: false
 
+Salsify/RailsApplicationMailer:
+  Description: 'Models must subclass ApplicationMailer.'
+  Enabled: false
+
 Salsify/RailsApplicationRecord:
   Description: 'Models must subclass ApplicationRecord.'
   Enabled: false

--- a/lib/rubocop/cop/salsify/rails_application_mailer.rb
+++ b/lib/rubocop/cop/salsify/rails_application_mailer.rb
@@ -1,0 +1,55 @@
+# encoding: utf-8
+
+require 'rubocop'
+
+module RuboCop
+  module Cop
+    module Salsify
+      # Check that mailers subclass ApplicationMailer with Rails 5.0
+      #
+      # @example
+      #
+      #  # good
+      #  class Tesla < ApplicationMailer
+      #    ...
+      #  end
+      #
+      #  # bad
+      #  class Yugo < ActionMailer::Base
+      #    ...
+      #  end
+      class RailsApplicationMailer < Cop
+
+        MSG = 'Mailers must subclass ApplicationMailer'.freeze
+        APPLICATION_MAILER = 'ApplicationMailer'.freeze
+        ACTIVE_MAILER_BASE_PATTERN = '(const (const nil :ActionMailer) :Base)'.freeze
+
+        def_node_matcher :mailer_class_definition, <<-PATTERN
+        (class (const _ !:ApplicationMailer) #{ACTIVE_MAILER_BASE_PATTERN} ...)
+        PATTERN
+
+        def_node_matcher :class_new_definition, <<-PATTERN
+        [!^(casgn nil :ApplicationMailer ...) (send (const nil :Class) :new #{ACTIVE_MAILER_BASE_PATTERN})]
+        PATTERN
+
+        def on_class(node)
+          mailer_class_definition(node) do
+            add_offense(node.children[1], :expression, MSG)
+          end
+        end
+
+        def on_send(node)
+          class_new_definition(node) do
+            add_offense(node.children.last, :expression, MSG)
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(node.source_range, APPLICATION_MAILER)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/salsify_rubocop.rb
+++ b/lib/salsify_rubocop.rb
@@ -13,6 +13,7 @@ config = RuboCop::ConfigLoader.merge_with_default(config, path)
 RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
 
 # cops
+require 'rubocop/cop/salsify/rails_application_mailer'
 require 'rubocop/cop/salsify/rails_application_serializer'
 require 'rubocop/cop/salsify/rails_application_record'
 require 'rubocop/cop/salsify/rspec_doc_string'

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SalsifyRubocop
-  VERSION = '0.48.0'.freeze
+  VERSION = '0.49.0'.freeze
 end

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SalsifyRubocop
-  VERSION = '0.49.0'.freeze
+  VERSION = '0.48.1'.freeze
 end

--- a/spec/rubocop/cop/salsify/rails_application_mailer_spec.rb
+++ b/spec/rubocop/cop/salsify/rails_application_mailer_spec.rb
@@ -61,7 +61,7 @@ describe RuboCop::Cop::Salsify::RailsApplicationMailer, :config do
     expect(autocorrect_source(cop, source)).to eq('Nested::MyMailer = Class.new(ApplicationMailer)')
   end
 
-  it "correct anonymous mailers" do
+  it "corrects anonymous mailers" do
     source = 'Class.new(ActionMailer::Base) {}'
     inspect_source(cop, source)
     expect(cop.messages).to eq(msgs)

--- a/spec/rubocop/cop/salsify/rails_application_mailer_spec.rb
+++ b/spec/rubocop/cop/salsify/rails_application_mailer_spec.rb
@@ -1,0 +1,77 @@
+# encoding utf-8
+# frozen_string_literal: true
+
+describe RuboCop::Cop::Salsify::RailsApplicationMailer, :config do
+  let(:msgs) { [described_class::MSG] }
+  let(:highlights) { ['ActionMailer::Base'] }
+
+  subject(:cop) { described_class.new(config) }
+
+  it "allows ApplicationMailer to be defined" do
+    source = "class ApplicationMailer < ActionMailer::Base\nend"
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it "corrects mailers that subclass ActionMailer::Base" do
+    source = "class MyMailer < ActionMailer::Base\nend"
+    inspect_source(cop, source)
+    expect(cop.messages).to eq(msgs)
+    expect(cop.highlights).to eq(highlights)
+    expect(autocorrect_source(cop, source)).to eq("class MyMailer < ApplicationMailer\nend")
+  end
+
+  it "corrects single-line class definitions" do
+    source = 'class MyMailer < ActionMailer::Base; end'
+    inspect_source(cop, source)
+    expect(cop.messages).to eq(msgs)
+    expect(cop.highlights).to eq(highlights)
+    expect(autocorrect_source(cop, source)).to eq('class MyMailer < ApplicationMailer; end')
+  end
+
+  it "corrects namespaced mailers that subclass ActionMailer::Base" do
+    source = "module Nested\n  class MyMailer < ActionMailer::Base\n  end\nend"
+    inspect_source(cop, source)
+    expect(cop.messages).to eq(msgs)
+    expect(cop.highlights).to eq(highlights)
+    expect(autocorrect_source(cop, source)).to eq("module Nested\n  class MyMailer < ApplicationMailer\n  end\nend")
+  end
+
+  it "corrects mailers defined using nested constants" do
+    source = "class Nested::MyMailer < ActionMailer::Base\nend"
+    inspect_source(cop, source)
+    expect(cop.messages).to eq(msgs)
+    expect(cop.highlights).to eq(highlights)
+    expect(autocorrect_source(cop, source)).to eq("class Nested::MyMailer < ApplicationMailer\nend")
+  end
+
+  it "corrects mailers defined using Class.new" do
+    source = 'MyMailer = Class.new(ActionMailer::Base)'
+    inspect_source(cop, source)
+    expect(cop.messages).to eq(msgs)
+    expect(cop.highlights).to eq(highlights)
+    expect(autocorrect_source(cop, source)).to eq('MyMailer = Class.new(ApplicationMailer)')
+  end
+
+  it "corrects nested mailers defined using Class.new" do
+    source = 'Nested::MyMailer = Class.new(ActionMailer::Base)'
+    inspect_source(cop, source)
+    expect(cop.messages).to eq(msgs)
+    expect(cop.highlights).to eq(highlights)
+    expect(autocorrect_source(cop, source)).to eq('Nested::MyMailer = Class.new(ApplicationMailer)')
+  end
+
+  it "correct anonymous mailers" do
+    source = 'Class.new(ActionMailer::Base) {}'
+    inspect_source(cop, source)
+    expect(cop.messages).to eq(msgs)
+    expect(cop.highlights).to eq(highlights)
+    expect(autocorrect_source(cop, source)).to eq('Class.new(ApplicationMailer) {}')
+  end
+
+  it "allows ApplicationMailer defined using Class.new" do
+    source = 'ApplicationMailer = Class.new(ActionMailer::Base)'
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
+  end
+end


### PR DESCRIPTION
Based on `RailsApplicationModel` and `RailsApplicationSerializer`, this adds a cop to check that all mailers subclass `ApplicationMailer`

prime @tjwp 