### PR TITLE
 Fix Salsify/StyleDig false positive in assignments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 inherit_from:
   - conf/rubocop.yml
 
+AllCops:
+  TargetRubyVersion: 2.3
+
 Metrics/LineLength:
   Exclude:
     - '*.gemspec'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: ruby
 rvm:
-  - 2.5.0
-  - 2.4.3
-  - 2.3.6
-  - 2.2.9
-before_install:
-  # Workaround for https://github.com/sickill/rainbow/issues/48
-  - gem update --system
+  - 2.5.1
+  - 2.4.4
+  - 2.3.7
 script:
   - bundle exec rubocop
   - bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # salsify_rubocop
 
+## v0.52.1.1
+- Fix `Salsify/StyleDig` false positive in assignments (see [#20](https://github.com/salsify/salsify_rubocop/issues/20)). 
+
 ## v0.52.1
 - Update to `rubocop` v0.52.1 and `rubocop-rspec` v1.21.0.
 

--- a/lib/rubocop/cop/salsify/style_dig.rb
+++ b/lib/rubocop/cop/salsify/style_dig.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This may be added in the near future to rubocop, see https://github.com/bbatsov/rubocop/issues/5332
 
 module RuboCop

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SalsifyRubocop
-  VERSION = '0.52.1'.freeze
+  VERSION = '0.52.1.1'.freeze
 end

--- a/spec/rubocop/cop/salsify/style_dig_spec.rb
+++ b/spec/rubocop/cop/salsify/style_dig_spec.rb
@@ -1,4 +1,3 @@
-# encoding utf-8
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Salsify::StyleDig, :config, :ruby23 do

--- a/spec/rubocop/cop/salsify/style_dig_spec.rb
+++ b/spec/rubocop/cop/salsify/style_dig_spec.rb
@@ -1,3 +1,4 @@
+# encoding utf-8
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Salsify::StyleDig, :config, :ruby23 do
@@ -15,7 +16,7 @@ describe RuboCop::Cop::Salsify::StyleDig, :config, :ruby23 do
     source = 'hash[one][two]'
     inspect_source(source)
     expect(cop.highlights).to eq([source])
-    expect(cop.messages).to eq(msgs)
+    expect(cop.messages).to match_array(msgs)
     expect(autocorrect_source(source)).to eq('hash.dig(one, two)')
   end
 
@@ -23,7 +24,7 @@ describe RuboCop::Cop::Salsify::StyleDig, :config, :ruby23 do
     source = 'hash[one][two][three]'
     inspect_source(source)
     expect(cop.highlights).to eq([source])
-    expect(cop.messages).to eq(msgs)
+    expect(cop.messages).to match_array(msgs)
     expect(autocorrect_source(source)).to eq('hash.dig(one, two, three)')
   end
 
@@ -31,7 +32,7 @@ describe RuboCop::Cop::Salsify::StyleDig, :config, :ruby23 do
     source = 'obj.hash[:one][:two]'
     inspect_source(source)
     expect(cop.highlights).to eq([source])
-    expect(cop.messages).to eq(msgs)
+    expect(cop.messages).to match_array(msgs)
     expect(autocorrect_source(source)).to eq('obj.hash.dig(:one, :two)')
   end
 
@@ -39,7 +40,7 @@ describe RuboCop::Cop::Salsify::StyleDig, :config, :ruby23 do
     source = 'call(array[0][1])'
     inspect_source(source)
     expect(cop.highlights).to eq(['array[0][1]'])
-    expect(cop.messages).to eq(msgs)
+    expect(cop.messages).to match_array(msgs)
     expect(autocorrect_source(source)).to eq('call(array.dig(0, 1))')
   end
 
@@ -47,7 +48,7 @@ describe RuboCop::Cop::Salsify::StyleDig, :config, :ruby23 do
     source = 'hash[one][two].foo'
     inspect_source(source)
     expect(cop.highlights).to eq(['hash[one][two]'])
-    expect(cop.messages).to eq(msgs)
+    expect(cop.messages).to match_array(msgs)
     expect(autocorrect_source(source)).to eq('hash.dig(one, two).foo')
   end
 
@@ -61,7 +62,53 @@ describe RuboCop::Cop::Salsify::StyleDig, :config, :ruby23 do
     source = 'blah ||= foo[bar][baz]'
     inspect_source(source)
     expect(cop.highlights).to eq(['foo[bar][baz]'])
-    expect(cop.messages).to eq(msgs)
+    expect(cop.messages).to match_array(msgs)
     expect(autocorrect_source(source)).to eq('blah ||= foo.dig(bar, baz)')
+  end
+
+  it "accepts nested access for increment" do
+    source = 'foo[bar][baz] += 1'
+    inspect_source(source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it "accepts nested access for assignment" do
+    source = 'foo[bar][baz] = 0'
+    inspect_source(source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it "corrects nested access with append" do
+    source = 'foo[bar][baz] << 1'
+    inspect_source(source)
+    expect(cop.highlights).to match_array(['foo[bar][baz]'])
+    expect(cop.messages).to match_array(msgs)
+    expect(autocorrect_source(source)).to eq('foo.dig(bar, baz) << 1')
+  end
+
+  it "accepts nested access that uses an inclusive range" do
+    source = 'foo[bar][0..2]'
+    inspect_source(source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it "accepts nested access that uses an exclusive range" do
+    source = 'foo[bar][0...2]'
+    inspect_source(source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it "corrects nested access before the use of an inclusive range" do
+    source = 'foo[bar][baz][0..2]'
+    inspect_source(source)
+    expect(cop.messages).to match_array(msgs)
+    expect(autocorrect_source(source)).to eq('foo.dig(bar, baz)[0..2]')
+  end
+
+  it "corrects nested access before the use of an exclusive range" do
+    source = 'foo[bar][baz][0...2]'
+    inspect_source(source)
+    expect(cop.messages).to match_array(msgs)
+    expect(autocorrect_source(source)).to eq('foo.dig(bar, baz)[0...2]')
   end
 end


### PR DESCRIPTION
Fixes #20. This pulls in changes to the `StyleDig` cop from ezcater. I also bumped the version of Rubies we were testing with and dropped testing against Ruby 2.2.

@cgrdavies - you're prime