### PR TITLE
Add cop that checks for use of unscoped. Update rubocop to v0.59.2 [ET-396]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # salsify_rubocop
 
+## v0.58.0.1
+- Add `Salsify/RailsUnscoped` cop.
+
 ## v0.58.0
 - Update `rubocop` to v0.58.0.
 - Update `rubocop-rspec` to v1.29.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # salsify_rubocop
 
-## v0.58.0.1
+## v0.59.0.1
+- Update `rubocop` to v0.59.0.
 - Add `Salsify/RailsUnscoped` cop.
 
 ## v0.58.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # salsify_rubocop
 
-## v0.59.0.1
-- Update `rubocop` to v0.59.0.
+## v0.59.2.1
+- Update `rubocop` to v0.59.2.
 - Add `Salsify/RailsUnscoped` cop.
 
 ## v0.58.0

--- a/conf/rubocop_rails.yml
+++ b/conf/rubocop_rails.yml
@@ -17,3 +17,6 @@ Rails/TimeZone:
 
 Rails/UniqBeforePluck:
   EnforcedStyle: aggressive
+
+Salsify/RailsUnscoped:
+  Enabled: true

--- a/config/default.yml
+++ b/config/default.yml
@@ -10,6 +10,10 @@ Salsify/RailsApplicationRecord:
   Description: 'Models must subclass ApplicationRecord.'
   Enabled: false
 
+Salsify/RailsUnscoped:
+  Description: 'Activerecord scopes cannot use unscoped.'
+  Enabled: false
+
 Salsify/RspecDocString:
   Description: 'Check that RSpec doc strings use the correct quoting.'
   Enabled: true

--- a/lib/rubocop/cop/salsify/rails_unscoped.rb
+++ b/lib/rubocop/cop/salsify/rails_unscoped.rb
@@ -1,7 +1,7 @@
 module RuboCop
   module Cop
     module Salsify
-      # Check that activerecord scopes do not use `unscoped`
+      # Check that Activerecord scopes do not use `unscoped`
       #
       # @example
       #

--- a/lib/rubocop/cop/salsify/rails_unscoped.rb
+++ b/lib/rubocop/cop/salsify/rails_unscoped.rb
@@ -13,12 +13,13 @@ module RuboCop
       class RailsUnscoped < Cop
         MSG = 'Explicitly remove scopes instead of using `unscoped`.'.freeze
 
-        def_node_matcher :unscoped?, <<-END
+        def_node_matcher :unscoped?, <<-PATTERN
           (send _ :unscoped)
-        END
+        PATTERN
 
         def on_send(node)
           return unless unscoped?(node)
+
           add_offense(node, location: :expression, message: MSG)
         end
       end

--- a/lib/rubocop/cop/salsify/rails_unscoped.rb
+++ b/lib/rubocop/cop/salsify/rails_unscoped.rb
@@ -11,7 +11,7 @@ module RuboCop
       #  # bad
       #  User.unscoped
       class RailsUnscoped < Cop
-        MSG = 'Explicitly remove scopes instead of using `unscoped`.'
+        MSG = 'Explicitly remove scopes instead of using `unscoped`.'.freeze
 
         def_node_matcher :unscoped?, <<-END
           (send _ :unscoped)

--- a/lib/rubocop/cop/salsify/rails_unscoped.rb
+++ b/lib/rubocop/cop/salsify/rails_unscoped.rb
@@ -1,0 +1,27 @@
+module RuboCop
+  module Cop
+    module Salsify
+      # Check that activerecord scopes do not use `unscoped`
+      #
+      # @example
+      #
+      #  # good
+      #  User.unscoped
+      #
+      #  # bad
+      #  User.strip_default_scope
+      class RailsUnscoped < Cop
+        MSG = 'Explicitly remove scopes instead of using `unscoped`.'
+
+        def_node_matcher :unscoped?, <<-END
+          (send _ :unscoped)
+        END
+
+        def on_send(node)
+          return unless unscoped?(node)
+          add_offense(node, location: :expression, message: MSG)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/salsify/rails_unscoped.rb
+++ b/lib/rubocop/cop/salsify/rails_unscoped.rb
@@ -6,10 +6,10 @@ module RuboCop
       # @example
       #
       #  # good
-      #  User.unscoped
+      #  User.strip_default_scope
       #
       #  # bad
-      #  User.strip_default_scope
+      #  User.unscoped
       class RailsUnscoped < Cop
         MSG = 'Explicitly remove scopes instead of using `unscoped`.'
 

--- a/lib/rubocop/cop/salsify/rspec_doc_string.rb
+++ b/lib/rubocop/cop/salsify/rspec_doc_string.rb
@@ -61,6 +61,7 @@ module RuboCop
         def wrong_quotes?(node)
           src = node.source
           return false if src.start_with?('%', '?')
+
           if style == :single_quotes
             src !~ /^'/ && !needs_escaping?(node.str_content)
           else

--- a/lib/rubocop/cop/salsify/style_dig.rb
+++ b/lib/rubocop/cop/salsify/style_dig.rb
@@ -29,6 +29,7 @@ module RuboCop
 
         def on_send(node)
           return unless nested_access_match(node) && !assignment?(node)
+
           match_node = node
           # walk to outermost access node
           match_node = match_node.parent while access_node?(match_node.parent)

--- a/lib/salsify_rubocop.rb
+++ b/lib/salsify_rubocop.rb
@@ -15,6 +15,7 @@ RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
 # cops
 require 'rubocop/cop/salsify/rails_application_mailer'
 require 'rubocop/cop/salsify/rails_application_serializer'
+require 'rubocop/cop/salsify/rails_unscoped'
 require 'rubocop/cop/salsify/rspec_doc_string'
 require 'rubocop/cop/salsify/rspec_dot_not_self_dot'
 require 'rubocop/cop/salsify/rspec_string_literals'

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SalsifyRubocop
-  VERSION = '0.58.0.rc1'.freeze
+  VERSION = '0.58.0.1.rc1'.freeze
 end

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SalsifyRubocop
-  VERSION = '0.58.0.1.rc1'.freeze
+  VERSION = '0.59.0.1.rc1'.freeze
 end

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SalsifyRubocop
-  VERSION = '0.59.0.1.rc1'.freeze
+  VERSION = '0.59.2.1.rc1'.freeze
 end

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.59.0'
+  spec.add_runtime_dependency 'rubocop', '~> 0.59.2'
   spec.add_runtime_dependency 'rubocop-rspec', '~> 1.29.0'
 end

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.58.0'
+  spec.add_runtime_dependency 'rubocop', '~> 0.59.0'
   spec.add_runtime_dependency 'rubocop-rspec', '~> 1.29.0'
 end

--- a/spec/rubocop/cop/salsify/rails_unscoped_spec.rb
+++ b/spec/rubocop/cop/salsify/rails_unscoped_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+describe RuboCop::Cop::Salsify::RailsUnscoped, :config do
+  let(:msgs) { [described_class::MSG] }
+
+  subject(:cop) { described_class.new(config) }
+
+  it "accepts scopes without `unscoped`" do
+    source = 'User.where(foo: bar)'
+    inspect_source(source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it "detects `unscoped` in scope with explicit model" do
+    source = 'User.where(foo: bar).unscoped'
+    inspect_source(source)
+    expect(cop.highlights).to eq([source])
+    expect(cop.messages).to match_array(msgs)
+  end
+
+  it "detects `unscoped` in scope with implicit model" do
+    source = 'where(foo: bar).unscoped'
+    inspect_source(source)
+    expect(cop.highlights).to eq([source])
+    expect(cop.messages).to match_array(msgs)
+  end
+end

--- a/spec/rubocop/cop/salsify/rspec_doc_string_spec.rb
+++ b/spec/rubocop/cop/salsify/rspec_doc_string_spec.rb
@@ -5,12 +5,12 @@ describe RuboCop::Cop::Salsify::RspecDocString, :config do
 
   shared_examples_for "always accepted strings" do |name|
     it "accepts `#{name}` with a single character" do
-      inspect_source(["#{name} ?a do", 'end'].join("\n"))
+      inspect_source(["#{name} ?a do", 'end'].join($RS))
       expect(cop.offenses).to be_empty
     end
 
     it "accepts `#{name}` with a %q string" do
-      inspect_source(["#{name} %q(doc string) do", 'end'].join("\n"))
+      inspect_source(["#{name} %q(doc string) do", 'end'].join($RS))
       expect(cop.offenses).to be_empty
     end
 
@@ -18,7 +18,7 @@ describe RuboCop::Cop::Salsify::RspecDocString, :config do
       # rubocop:disable Lint/InterpolationCheck
       doc_string = '"#{\'DOC\'.downcase} string"'
       # rubocop:enable Lint/InterpolationCheck
-      inspect_source(["#{name} #{doc_string} do", 'end'].join("\n"))
+      inspect_source(["#{name} #{doc_string} do", 'end'].join($RS))
       expect(cop.offenses).to be_empty
     end
   end
@@ -29,10 +29,10 @@ describe RuboCop::Cop::Salsify::RspecDocString, :config do
     described_class::DOCUMENTED_METHODS.each do |name|
       it "finds `#{name}` with a single-quoted string" do
         source = ["#{name} 'doc string' do", 'end']
-        inspect_source(source.join("\n"))
+        inspect_source(source.join($RS))
         expect(cop.messages).to eq([described_class::DOUBLE_QUOTE_MSG])
         expect(cop.highlights).to eq(["'doc string'"])
-        expect(autocorrect_source(source.join("\n")))
+        expect(autocorrect_source(source.join($RS)))
           .to eq("#{name} \"doc string\" do\nend")
       end
 
@@ -40,7 +40,7 @@ describe RuboCop::Cop::Salsify::RspecDocString, :config do
         inspect_source([
           "#{name} \"doc string\" do",
           'end'
-        ].join("\n"))
+        ].join($RS))
         expect(cop.offenses).to be_empty
       end
 
@@ -54,10 +54,10 @@ describe RuboCop::Cop::Salsify::RspecDocString, :config do
     described_class::DOCUMENTED_METHODS.each do |name|
       it "finds `#{name}` with a double-quoted string" do
         source = ["#{name} \"doc string\" do", 'end']
-        inspect_source(source.join("\n"))
+        inspect_source(source.join($RS))
         expect(cop.messages).to eq([described_class::SINGLE_QUOTE_MSG])
         expect(cop.highlights).to eq(['"doc string"'])
-        expect(autocorrect_source(source.join("\n")))
+        expect(autocorrect_source(source.join($RS)))
           .to eq("#{name} 'doc string' do\nend")
       end
 
@@ -65,7 +65,7 @@ describe RuboCop::Cop::Salsify::RspecDocString, :config do
         inspect_source([
           "#{name} 'doc string' do",
           'end'
-        ].join("\n"))
+        ].join($RS))
         expect(cop.offenses).to be_empty
       end
 

--- a/spec/rubocop/cop/salsify/rspec_doc_string_spec.rb
+++ b/spec/rubocop/cop/salsify/rspec_doc_string_spec.rb
@@ -5,12 +5,12 @@ describe RuboCop::Cop::Salsify::RspecDocString, :config do
 
   shared_examples_for "always accepted strings" do |name|
     it "accepts `#{name}` with a single character" do
-      inspect_source(["#{name} ?a do", 'end'])
+      inspect_source(["#{name} ?a do", 'end'].join("\n"))
       expect(cop.offenses).to be_empty
     end
 
     it "accepts `#{name}` with a %q string" do
-      inspect_source(["#{name} %q(doc string) do", 'end'])
+      inspect_source(["#{name} %q(doc string) do", 'end'].join("\n"))
       expect(cop.offenses).to be_empty
     end
 
@@ -18,7 +18,7 @@ describe RuboCop::Cop::Salsify::RspecDocString, :config do
       # rubocop:disable Lint/InterpolationCheck
       doc_string = '"#{\'DOC\'.downcase} string"'
       # rubocop:enable Lint/InterpolationCheck
-      inspect_source(["#{name} #{doc_string} do", 'end'])
+      inspect_source(["#{name} #{doc_string} do", 'end'].join("\n"))
       expect(cop.offenses).to be_empty
     end
   end
@@ -29,10 +29,10 @@ describe RuboCop::Cop::Salsify::RspecDocString, :config do
     described_class::DOCUMENTED_METHODS.each do |name|
       it "finds `#{name}` with a single-quoted string" do
         source = ["#{name} 'doc string' do", 'end']
-        inspect_source(source)
+        inspect_source(source.join("\n"))
         expect(cop.messages).to eq([described_class::DOUBLE_QUOTE_MSG])
         expect(cop.highlights).to eq(["'doc string'"])
-        expect(autocorrect_source(source))
+        expect(autocorrect_source(source.join("\n")))
           .to eq("#{name} \"doc string\" do\nend")
       end
 
@@ -40,7 +40,7 @@ describe RuboCop::Cop::Salsify::RspecDocString, :config do
         inspect_source([
                          "#{name} \"doc string\" do",
                          'end'
-                       ])
+                       ].join("\n"))
         expect(cop.offenses).to be_empty
       end
 
@@ -54,10 +54,10 @@ describe RuboCop::Cop::Salsify::RspecDocString, :config do
     described_class::DOCUMENTED_METHODS.each do |name|
       it "finds `#{name}` with a double-quoted string" do
         source = ["#{name} \"doc string\" do", 'end']
-        inspect_source(source)
+        inspect_source(source.join("\n"))
         expect(cop.messages).to eq([described_class::SINGLE_QUOTE_MSG])
         expect(cop.highlights).to eq(['"doc string"'])
-        expect(autocorrect_source(source))
+        expect(autocorrect_source(source.join("\n")))
           .to eq("#{name} 'doc string' do\nend")
       end
 
@@ -65,7 +65,7 @@ describe RuboCop::Cop::Salsify::RspecDocString, :config do
         inspect_source([
                          "#{name} 'doc string' do",
                          'end'
-                       ])
+                       ].join("\n"))
         expect(cop.offenses).to be_empty
       end
 

--- a/spec/rubocop/cop/salsify/rspec_doc_string_spec.rb
+++ b/spec/rubocop/cop/salsify/rspec_doc_string_spec.rb
@@ -38,9 +38,9 @@ describe RuboCop::Cop::Salsify::RspecDocString, :config do
 
       it "accepts `#{name}` with a double-quoted string" do
         inspect_source([
-                         "#{name} \"doc string\" do",
-                         'end'
-                       ].join("\n"))
+          "#{name} \"doc string\" do",
+          'end'
+        ].join("\n"))
         expect(cop.offenses).to be_empty
       end
 
@@ -63,9 +63,9 @@ describe RuboCop::Cop::Salsify::RspecDocString, :config do
 
       it "accepts `#{name}` with a single-quoted string" do
         inspect_source([
-                         "#{name} 'doc string' do",
-                         'end'
-                       ].join("\n"))
+          "#{name} 'doc string' do",
+          'end'
+        ].join("\n"))
         expect(cop.offenses).to be_empty
       end
 

--- a/spec/rubocop/cop/salsify/rspec_string_literals_spec.rb
+++ b/spec/rubocop/cop/salsify/rspec_string_literals_spec.rb
@@ -5,12 +5,12 @@ describe RuboCop::Cop::Salsify::RspecStringLiterals, :config do
 
   shared_examples_for "string quoting exceptions" do |name|
     it "accepts `#{name}` with a single character" do
-      inspect_source(["#{name} 'ignored' do", '?a', 'end'].join("\n"))
+      inspect_source(["#{name} 'ignored' do", '?a', 'end'].join($RS))
       expect(cop.offenses).to be_empty
     end
 
     it "accepts `#{name}` with a %q string" do
-      inspect_source(["#{name} 'ignored' do", '%q(doc string)', 'end'].join("\n"))
+      inspect_source(["#{name} 'ignored' do", '%q(doc string)', 'end'].join($RS))
       expect(cop.offenses).to be_empty
     end
 
@@ -18,7 +18,7 @@ describe RuboCop::Cop::Salsify::RspecStringLiterals, :config do
       # rubocop:disable Lint/InterpolationCheck
       doc_string = '"#{\'DOC\'.downcase} string"'
       # rubocop:enable Lint/InterpolationCheck
-      inspect_source(["#{name} 'ignored' do", doc_string, 'end'].join("\n"))
+      inspect_source(["#{name} 'ignored' do", doc_string, 'end'].join($RS))
       expect(cop.offenses).to be_empty
     end
   end
@@ -30,16 +30,16 @@ describe RuboCop::Cop::Salsify::RspecStringLiterals, :config do
       context "within #{name}" do
         it "corrects a double-quoted string" do
           source = ["#{name} \"doc string\" do", '"literal"', 'end']
-          inspect_source(source.join("\n"))
+          inspect_source(source.join($RS))
           expect(cop.messages).to eq([described_class::SINGLE_QUOTE_MSG])
           expect(cop.highlights).to eq([source[1]])
-          expect(autocorrect_source(source.join("\n")))
+          expect(autocorrect_source(source.join($RS)))
             .to eq("#{name} \"doc string\" do\n'literal'\nend")
         end
 
         it "accepts a single-quoted string" do
           source = ["#{name} 'doc string' do", "'literal'", 'end']
-          inspect_source(source.join("\n"))
+          inspect_source(source.join($RS))
           expect(cop.offenses).to be_empty
         end
 
@@ -55,16 +55,16 @@ describe RuboCop::Cop::Salsify::RspecStringLiterals, :config do
       context "within #{name}" do
         it "corrects a single-quoted string" do
           source = ["#{name} 'doc string' do", "'literal'", 'end']
-          inspect_source(source.join("\n"))
+          inspect_source(source.join($RS))
           expect(cop.messages).to eq([described_class::DOUBLE_QUOTE_MSG])
           expect(cop.highlights).to eq([source[1]])
-          expect(autocorrect_source(source.join("\n")))
+          expect(autocorrect_source(source.join($RS)))
             .to eq("#{name} 'doc string' do\n\"literal\"\nend")
         end
 
         it "accepts a double-quoted string" do
           source = ["#{name} \"doc string\" do", '"literal"', 'end']
-          inspect_source(source.join("\n"))
+          inspect_source(source.join($RS))
           expect(cop.offenses).to be_empty
         end
 

--- a/spec/rubocop/cop/salsify/rspec_string_literals_spec.rb
+++ b/spec/rubocop/cop/salsify/rspec_string_literals_spec.rb
@@ -5,12 +5,12 @@ describe RuboCop::Cop::Salsify::RspecStringLiterals, :config do
 
   shared_examples_for "string quoting exceptions" do |name|
     it "accepts `#{name}` with a single character" do
-      inspect_source(["#{name} 'ignored' do", '?a', 'end'])
+      inspect_source(["#{name} 'ignored' do", '?a', 'end'].join("\n"))
       expect(cop.offenses).to be_empty
     end
 
     it "accepts `#{name}` with a %q string" do
-      inspect_source(["#{name} 'ignored' do", '%q(doc string)', 'end'])
+      inspect_source(["#{name} 'ignored' do", '%q(doc string)', 'end'].join("\n"))
       expect(cop.offenses).to be_empty
     end
 
@@ -18,7 +18,7 @@ describe RuboCop::Cop::Salsify::RspecStringLiterals, :config do
       # rubocop:disable Lint/InterpolationCheck
       doc_string = '"#{\'DOC\'.downcase} string"'
       # rubocop:enable Lint/InterpolationCheck
-      inspect_source(["#{name} 'ignored' do", doc_string, 'end'])
+      inspect_source(["#{name} 'ignored' do", doc_string, 'end'].join("\n"))
       expect(cop.offenses).to be_empty
     end
   end
@@ -30,16 +30,16 @@ describe RuboCop::Cop::Salsify::RspecStringLiterals, :config do
       context "within #{name}" do
         it "corrects a double-quoted string" do
           source = ["#{name} \"doc string\" do", '"literal"', 'end']
-          inspect_source(source)
+          inspect_source(source.join("\n"))
           expect(cop.messages).to eq([described_class::SINGLE_QUOTE_MSG])
           expect(cop.highlights).to eq([source[1]])
-          expect(autocorrect_source(source))
+          expect(autocorrect_source(source.join("\n")))
             .to eq("#{name} \"doc string\" do\n'literal'\nend")
         end
 
         it "accepts a single-quoted string" do
           source = ["#{name} 'doc string' do", "'literal'", 'end']
-          inspect_source(source)
+          inspect_source(source.join("\n"))
           expect(cop.offenses).to be_empty
         end
 
@@ -55,16 +55,16 @@ describe RuboCop::Cop::Salsify::RspecStringLiterals, :config do
       context "within #{name}" do
         it "corrects a single-quoted string" do
           source = ["#{name} 'doc string' do", "'literal'", 'end']
-          inspect_source(source)
+          inspect_source(source.join("\n"))
           expect(cop.messages).to eq([described_class::DOUBLE_QUOTE_MSG])
           expect(cop.highlights).to eq([source[1]])
-          expect(autocorrect_source(source))
+          expect(autocorrect_source(source.join("\n")))
             .to eq("#{name} 'doc string' do\n\"literal\"\nend")
         end
 
         it "accepts a double-quoted string" do
           source = ["#{name} \"doc string\" do", '"literal"', 'end']
-          inspect_source(source)
+          inspect_source(source.join("\n"))
           expect(cop.offenses).to be_empty
         end
 


### PR DESCRIPTION
**Context**
[`ET-396`](https://salsify.atlassian.net/browse/ET-396) We shouldn't use `unscoped` on Activerecord relations since it has very confusing behavior.  It strips default scopes, previously applied scopes, pagination, ordering etc. The incorrect use becomes difficult to detect in tests since we often assume activerecord queries behave correctly and don't create unnecessary data that should _not_ be returned by queries.

The typical intended use of `unscoped` is to remove the current organization scope or remove the destroyed scope and we should encourage developers to be explicit. 

**Changes**
Added a new `Salsify/RailsUnscoped` cop and some specs.  I plan on updating dandelion to this once merged and (attempting to) resolve existing offenses.

First time writing a cop so let me know anything I can improve.

Prime @jturkel 
cc @salsify/laser-viper 