### PR TITLE
Update Rubocop to 0.58.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # salsify_rubocop
 
+## v0.58.0
+- Update `rubocop` to v0.58.0.
+- Update `rubocop-rspec` to v1.29.0.
+- Adjust Ruby version configuration in `Salsify/StyleDig` spec.
+
 ## v0.52.1.1
 - Fix `Salsify/StyleDig` false positive in assignments (see [#20](https://github.com/salsify/salsify_rubocop/issues/20)). 
 

--- a/lib/salsify_rubocop.rb
+++ b/lib/salsify_rubocop.rb
@@ -3,7 +3,7 @@ require 'rubocop-rspec'
 
 # Because RuboCop doesn't yet support plugins, we have to monkey patch in a
 # bit of our configuration. Based on approach from rubocop-rspec:
-DEFAULT_FILES = File.expand_path('../../config/default.yml', __FILE__)
+DEFAULT_FILES = File.expand_path('../config/default.yml', __dir__)
 
 path = File.absolute_path(DEFAULT_FILES)
 hash = RuboCop::ConfigLoader.send(:load_yaml_configuration, path)

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SalsifyRubocop
-  VERSION = '0.58.0'.freeze
+  VERSION = '0.58.0.rc1'.freeze
 end

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SalsifyRubocop
-  VERSION = '0.52.1.1'.freeze
+  VERSION = '0.58.0'.freeze
 end

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.52.1'
-  spec.add_runtime_dependency 'rubocop-rspec', '~> 1.21.0'
+  spec.add_runtime_dependency 'rubocop', '~> 0.58.0'
+  spec.add_runtime_dependency 'rubocop-rspec', '~> 1.29.0'
 end

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'salsify_rubocop/version'
 

--- a/spec/rubocop/cop/salsify/style_dig_spec.rb
+++ b/spec/rubocop/cop/salsify/style_dig_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-describe RuboCop::Cop::Salsify::StyleDig, :config, :ruby23 do
+describe RuboCop::Cop::Salsify::StyleDig, :config do
   let(:msgs) { [described_class::MSG] }
 
   subject(:cop) { described_class.new(config) }
+  let(:ruby_version) { 2.3 }
 
   it "accepts non-nested access" do
     source = 'ary[0]'

--- a/spec/rubocop/cop/salsify/style_dig_spec.rb
+++ b/spec/rubocop/cop/salsify/style_dig_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Salsify::StyleDig, :config do
+  let(:ruby_version) { 2.3 }
   let(:msgs) { [described_class::MSG] }
 
   subject(:cop) { described_class.new(config) }
-  let(:ruby_version) { 2.3 }
 
   it "accepts non-nested access" do
     source = 'ary[0]'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'salsify_rubocop'
 
 require 'rubocop/rspec/support'


### PR DESCRIPTION
Motivation: Version 4.11.0 of `factory_bot` deprecated static attributes in factories:

https://github.com/thoughtbot/factory_bot/blob/master/NEWS
> 4.11.0 (August, 15, 2018)
  Bugfix: Do not raise error for valid build_stubbed methods: decrement, increment, and toggle
  Bugfix: Do not add timestamps with build_stubbed for objects that shouldn't have timestamps
  Deprecate static attributes

This means we get lots of deprecation warnings when running specs:
```
DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block:

key { "Key" }

To automatically update from static attributes to dynamic ones,
install rubocop-rspec and run:

rubocop \
  --require rubocop-rspec \
  --only FactoryBot/AttributeDefinedStatically \
  --auto-correct
```

I need `rubocop-rspec` >= `v1.28.0` in order to run perform the auto-correct. Hence we need a newer `rubocop` version.

