### PR TITLE
Upgrade Rubocop to 0.60.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # salsify_rubocop
 
+## v0.60.0
+- Upgrade to `rubocop` v0.60.0
+
 ## v0.59.2.1
 - Update `rubocop` to v0.59.2.
 - Add `Salsify/RailsUnscoped` cop.

--- a/lib/rubocop/cop/salsify/rspec_dot_not_self_dot.rb
+++ b/lib/rubocop/cop/salsify/rspec_dot_not_self_dot.rb
@@ -17,7 +17,7 @@ module RuboCop
       #   end
       class RspecDotNotSelfDot < Cop
 
-        SELF_DOT_REGEXP = /["']self\./
+        SELF_DOT_REGEXP = /["']self\./.freeze
         MSG = 'Use ".<class method>" instead of "self.<class method>" for example group description.'.freeze
 
         def_node_matcher :example_group_match, <<-PATTERN

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SalsifyRubocop
-  VERSION = '0.59.2.1.rc1'.freeze
+  VERSION = '0.60.0'.freeze
 end

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.59.2'
+  spec.add_runtime_dependency 'rubocop', '>= 0.60.0'
   spec.add_runtime_dependency 'rubocop-rspec', '~> 1.29.0'
 end

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.60.0'
+  spec.add_runtime_dependency 'rubocop', '~> 0.60.0'
   spec.add_runtime_dependency 'rubocop-rspec', '~> 1.29.0'
 end


### PR DESCRIPTION
Trying to upgrade Delayed Job Extensions in Dandelion gave me all sorts of conflicts with Rubocop. Upgrading Rubocop to 0.60 in `salsify_rubocop` locally fixed it.