### PR TITLE
Upgrade to Rubocop 0.62.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ rvm:
   - 2.5.1
   - 2.4.4
   - 2.3.7
+before_install:
+  - gem update --system
+  - gem install bundler
 script:
   - bundle exec rubocop
   - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
-  - 2.5.1
-  - 2.4.4
-  - 2.3.7
+  - 2.6.0
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8
 before_install:
   - gem update --system
   - gem install bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # salsify_rubocop
 
 ## v0.62.0
-- Upgrade to `rubocop` v0.60.0
+- Upgrade to `rubocop` v0.62.0
 - Upgrade to `rubocop_rspec` v1.31.0
 
 ## v0.60.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # salsify_rubocop
 
+## v0.62.0
+- Upgrade to `rubocop` v0.60.0
+- Upgrade to `rubocop_rspec` v1.31.0
+
 ## v0.60.0.1
-- Upgrade to `rubocop_rspec` 1.30.1
+- Upgrade to `rubocop_rspec` v1.30.1
 
 ## v0.60.0
 - Upgrade to `rubocop` v0.60.0
@@ -16,7 +20,7 @@
 - Adjust Ruby version configuration in `Salsify/StyleDig` spec.
 
 ## v0.52.1.1
-- Fix `Salsify/StyleDig` false positive in assignments (see [#20](https://github.com/salsify/salsify_rubocop/issues/20)). 
+- Fix `Salsify/StyleDig` false positive in assignments (see [#20](https://github.com/salsify/salsify_rubocop/issues/20)).
 
 ## v0.52.1
 - Update to `rubocop` v0.52.1 and `rubocop-rspec` v1.21.0.

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.60.0'
-  spec.add_runtime_dependency 'rubocop-rspec', '~> 1.30.1'
+  spec.add_runtime_dependency 'rubocop', '~> 0.62.0'
+  spec.add_runtime_dependency 'rubocop-rspec', '~> 1.31.0'
 end


### PR DESCRIPTION
fixes compatibility issues with ruby 2.6, eliminates a bunch of false positives, and adds `Performance/OpenStruct` and `Rails/LinkToBlank` cops

ran against content flow service and it fixed a false positive that we had to `# rubocop:disable` 🥂 

prime: @jturkel 