### PR TITLE
Remove percent-style WordArrays

### DIFF
--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -185,4 +185,7 @@ Style/StructInheritance:
   Enabled: false
 
 Style/WordArray:
+  EnforcedStyle: brackets 
+
+Style/SymbolArray:
   EnforcedStyle: brackets

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -183,3 +183,6 @@ Style/NumericLiterals:
 
 Style/StructInheritance:
   Enabled: false
+
+Style/WordArray:
+  EnforcedStyle: brackets

--- a/lib/rubocop/cop/salsify/rspec_doc_string.rb
+++ b/lib/rubocop/cop/salsify/rspec_doc_string.rb
@@ -26,7 +26,7 @@ module RuboCop
           'Example Group/Example doc strings must be double-quoted.'.freeze
 
         SHARED_EXAMPLES = RuboCop::RSpec::Language::SelectorSet.new(
-          %i(include_examples it_behaves_like it_should_behave_like include_context)
+          [:include_examples, :it_behaves_like, :it_should_behave_like, :include_context]
         ).freeze
 
         DOCUMENTED_METHODS = (RuboCop::RSpec::Language::ExampleGroups::ALL +

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SalsifyRubocop
-  VERSION = '0.62.0'.freeze
+  VERSION = '0.63.0'.freeze
 end


### PR DESCRIPTION
I'm putting this up largely for discussion. This cop has never made sense to me, as it seems to enforce a style almost no one follows by default, while adding a weird edge-case of arrays of particular types not needing comma's between elements, etc.

prime: @ecopoesis 