### PR TITLE
Enable LineLength and FrozenStringLiteral cops

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in salsify_rubocop.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -67,7 +67,7 @@ Naming/FileName:
     - 'Appraisals'
 
 Style/FrozenStringLiteralComment:
-  Enabled: false
+  Enabled: true
 
 Style/GuardClause:
   Enabled: false
@@ -152,10 +152,12 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Enabled: false
 
-# Disabling line length enforcement since annotate generates
-# some pretty long lines
 Layout/LineLength:
-  Enabled: false
+  Enabled: true
+  Max: 120
+  IgnoreCopDirectives: true
+  IgnoredPatterns:
+    - ^#
 
 Metrics/MethodLength:
   Enabled: false

--- a/lib/rubocop/cop/salsify/rails_application_mailer.rb
+++ b/lib/rubocop/cop/salsify/rails_application_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Salsify
@@ -19,9 +21,9 @@ module RuboCop
 
         minimum_target_rails_version 5.0
 
-        MSG = 'Mailers should subclass `ApplicationMailer`.'.freeze
-        SUPERCLASS = 'ApplicationMailer'.freeze
-        BASE_PATTERN = '(const (const nil? :ActionMailer) :Base)'.freeze
+        MSG = 'Mailers should subclass `ApplicationMailer`.'
+        SUPERCLASS = 'ApplicationMailer'
+        BASE_PATTERN = '(const (const nil? :ActionMailer) :Base)'
 
         include RuboCop::Cop::EnforceSuperclass
 

--- a/lib/rubocop/cop/salsify/rails_application_serializer.rb
+++ b/lib/rubocop/cop/salsify/rails_application_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Salsify
@@ -19,9 +21,9 @@ module RuboCop
 
         minimum_target_rails_version 5.0
 
-        MSG = 'Serializers should subclass `ApplicationSerializer`.'.freeze
-        SUPERCLASS = 'ApplicationSerializer'.freeze
-        BASE_PATTERN = '(const (const nil? :ActiveModel) :Serializer)'.freeze
+        MSG = 'Serializers should subclass `ApplicationSerializer`.'
+        SUPERCLASS = 'ApplicationSerializer'
+        BASE_PATTERN = '(const (const nil? :ActiveModel) :Serializer)'
 
         include RuboCop::Cop::EnforceSuperclass
 

--- a/lib/rubocop/cop/salsify/rails_unscoped.rb
+++ b/lib/rubocop/cop/salsify/rails_unscoped.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Salsify
@@ -11,7 +13,7 @@ module RuboCop
       #  # bad
       #  User.unscoped
       class RailsUnscoped < Cop
-        MSG = 'Explicitly remove scopes instead of using `unscoped`.'.freeze
+        MSG = 'Explicitly remove scopes instead of using `unscoped`.'
 
         def_node_matcher :unscoped?, <<-PATTERN
           (send _ :unscoped)

--- a/lib/rubocop/cop/salsify/rspec_doc_string.rb
+++ b/lib/rubocop/cop/salsify/rspec_doc_string.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Salsify
@@ -21,9 +23,9 @@ module RuboCop
         include ConfigurableEnforcedStyle
 
         SINGLE_QUOTE_MSG =
-          'Example Group/Example doc strings must be single-quoted.'.freeze
+          'Example Group/Example doc strings must be single-quoted.'
         DOUBLE_QUOTE_MSG =
-          'Example Group/Example doc strings must be double-quoted.'.freeze
+          'Example Group/Example doc strings must be double-quoted.'
 
         SHARED_EXAMPLES = RuboCop::RSpec::Language::SelectorSet.new(
           [:include_examples, :it_behaves_like, :it_should_behave_like, :include_context]

--- a/lib/rubocop/cop/salsify/rspec_dot_not_self_dot.rb
+++ b/lib/rubocop/cop/salsify/rspec_dot_not_self_dot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Salsify
@@ -18,7 +20,7 @@ module RuboCop
       class RspecDotNotSelfDot < Cop
 
         SELF_DOT_REGEXP = /["']self\./.freeze
-        MSG = 'Use ".<class method>" instead of "self.<class method>" for example group description.'.freeze
+        MSG = 'Use ".<class method>" instead of "self.<class method>" for example group description.'
 
         def_node_matcher :example_group_match, <<-PATTERN
           (send _ #{RuboCop::RSpec::Language::ExampleGroups::ALL.node_pattern_union} $_ ...)

--- a/lib/rubocop/cop/salsify/rspec_string_literals.rb
+++ b/lib/rubocop/cop/salsify/rspec_string_literals.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Salsify
@@ -16,9 +18,9 @@ module RuboCop
         DOCUMENTED_METHODS = RuboCop::Cop::Salsify::RspecDocString::DOCUMENTED_METHODS
 
         SINGLE_QUOTE_MSG = 'Prefer single-quoted strings unless you need ' \
-          'interpolation or special symbols.'.freeze
+          'interpolation or special symbols.'
         DOUBLE_QUOTE_MSG = 'Prefer double-quoted strings unless you need ' \
-          'single quotes to avoid extra backslashes for escaping.'.freeze
+          'single quotes to avoid extra backslashes for escaping.'
 
         def autocorrect(node)
           StringLiteralCorrector.correct(node, style)

--- a/lib/rubocop/cop/salsify/style_dig.rb
+++ b/lib/rubocop/cop/salsify/style_dig.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This may be added in the near future to rubocop, see https://github.com/bbatsov/rubocop/issues/5332
 
 module RuboCop
@@ -21,7 +23,7 @@ module RuboCop
 
         minimum_target_ruby_version 2.3
 
-        MSG = 'Use `dig` for nested access.'.freeze
+        MSG = 'Use `dig` for nested access.'
 
         def_node_matcher :nested_access_match, <<-PATTERN
           (send (send (send _receiver !:[]) :[] !{irange erange}) :[] !{irange erange})

--- a/lib/rubocop/rspec/language/each_selector.rb
+++ b/lib/rubocop/rspec/language/each_selector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Monkey-patch SelectorSet to allow enumeration of selectors.
 
 module RuboCop

--- a/lib/salsify_rubocop.rb
+++ b/lib/salsify_rubocop.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'salsify_rubocop/version'
 require 'rubocop-performance'
 require 'rubocop-rails'

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SalsifyRubocop
-  VERSION = '0.78.1'.freeze
+  VERSION = '0.78.1'
 end

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'salsify_rubocop/version'

--- a/spec/salsify_rubocop_spec.rb
+++ b/spec/salsify_rubocop_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SalsifyRubocop do
   it "has a version number" do
     expect(SalsifyRubocop::VERSION).not_to be nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'salsify_rubocop'
 


### PR DESCRIPTION
[As requested here](https://github.com/salsify/salsify_rubocop/pull/31#pullrequestreview-338673897)

To be honest I don't love this since it may require updating a lot of files in a project.

Would you agree that it should not be a requirement to update to rubocop 0.78 / ruby 2.7 and this can be added in a separate release?

prime: @jturkel 