### PR TITLE
Fix "`Style/SymbolArray` is concealed" warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # salsify_rubocop
 
+## v0.78.1
+- Fix "`Style/SymbolArray` is concealed by line 190" warning
+
 ## v0.78.0
 - Upgrade to `rubocop` v0.78.0
 - Upgrade to `rubocop_rspec` v1.37.0

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -134,10 +134,6 @@ Style/StringLiterals:
   Exclude:
     - 'spec/**/*'
 
-# We don't require %i() for an array of symbols.
-Style/SymbolArray:
-  Enabled: false
-
 Naming/VariableNumber:
   Enabled: false
 

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SalsifyRubocop
-  VERSION = '0.78.0'.freeze
+  VERSION = '0.78.1'.freeze
 end


### PR DESCRIPTION
We have conflicting cops for `Style/SymbolArray` which a new version of rubocop now warns us about:

```
salsify_rubocop-0.78.0/conf/rubocop_without_rspec.yml:138: `Style/SymbolArray` is concealed by line 190
```

prime: @ric2b 