### PR TITLE
Upgrate to rubocop 0.85.0 and enable `Bundler/GemComment` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_from:
   - conf/rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 Layout/LineLength:
   Exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
   - 2.6.0
   - 2.5.3
   - 2.4.5
-  - 2.3.8
 before_install:
   - gem update --system
   - gem install bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # salsify_rubocop
 
+## 0.85.0
+- Upgrate to `rubocop` v0.85.0
+- Enable enforcement of Gem comments when specifying versions or sources 
+- Drop support for Ruby 2.3, as rubocop v0.81+ doesn't support it anymore
+
 ## v0.78.1
 - Fix "`Style/SymbolArray` is concealed by line 190" warning
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Upgrate to `rubocop` v0.85.0
 - Enable enforcement of Gem comments when specifying versions or sources 
 - Drop support for Ruby 2.3, as rubocop v0.81+ doesn't support it anymore
+- Add `FrozenStringLiteralComment` and `LineLength` (max 120) rules.
 
 ## v0.78.1
 - Fix "`Style/SymbolArray` is concealed by line 190" warning

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -9,6 +9,15 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
 
+Bundler/GemComment:
+  Enabled: true
+  OnlyFor:
+    - 'version_specifiers'
+    - 'source'
+    - 'git'
+    - 'github'
+    - 'gist'
+
 # This cop has poor handling for the common case of a lambda arg in a DSL
 Lint/AmbiguousBlockAssociation:
   Enabled: false

--- a/lib/rubocop/cop/salsify/rspec_dot_not_self_dot.rb
+++ b/lib/rubocop/cop/salsify/rspec_dot_not_self_dot.rb
@@ -28,7 +28,7 @@ module RuboCop
 
         def on_send(node)
           example_group_match(node) do |doc|
-            add_offense(doc) if SELF_DOT_REGEXP =~ doc.source
+            add_offense(doc) if SELF_DOT_REGEXP.match?(doc.source)
           end
         end
 

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SalsifyRubocop
-  VERSION = '0.78.1'
+  VERSION = '0.85.0'
 end

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -30,6 +30,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.4'
+
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.78.0'
+  spec.add_runtime_dependency 'rubocop', '~> 0.85.0'
   spec.add_runtime_dependency 'rubocop-performance', '~> 1.5.0'
   spec.add_runtime_dependency 'rubocop-rails', '~> 2.4.0'
   spec.add_runtime_dependency 'rubocop-rspec', '~> 1.37.0'

--- a/spec/rubocop/cop/salsify/style_dig_spec.rb
+++ b/spec/rubocop/cop/salsify/style_dig_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Salsify::StyleDig, :config do
-  let(:ruby_version) { 2.3 }
+  let(:ruby_version) { 2.4 }
   let(:msgs) { [described_class::MSG] }
 
   subject(:cop) { described_class.new(config) }


### PR DESCRIPTION
- Upgrate to `rubocop` v0.85.0
- Enable enforcement of Gem comments when specifying versions or sources 
- Drop support for Ruby 2.3, as rubocop v0.81+ doesn't support it anymore

prime: @jturkel 