### PR TITLE
Update rubocop to 0.91.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # salsify_rubocop
 
+## 0.91.0
+
+- Upgrade to `rubocop` v0.91.0
+
 ## 0.85.0
-- Upgrate to `rubocop` v0.85.0
+- Upgrade to `rubocop` v0.85.0
 - Enable enforcement of Gem comments when specifying versions or sources 
 - Drop support for Ruby 2.3, as rubocop v0.81+ doesn't support it anymore
 - Add `FrozenStringLiteralComment` and `LineLength` (max 120) rules.

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SalsifyRubocop
-  VERSION = '0.85.0'
+  VERSION = '0.91.0'
 end

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.85.0'
+  spec.add_runtime_dependency 'rubocop', '~> 0.91.0'
   spec.add_runtime_dependency 'rubocop-performance', '~> 1.5.0'
   spec.add_runtime_dependency 'rubocop-rails', '~> 2.4.0'
   spec.add_runtime_dependency 'rubocop-rspec', '~> 1.37.0'


### PR DESCRIPTION
Use the updated `0.91.0` version of rubocop to fix some errors we are seeing in `svalbard` https://app.circleci.com/pipelines/github/salsify/svalbard/205/workflows/7a8e6278-f03c-4bf1-a877-7135d695ab94/jobs/194

Tested this on `svalbard` by setting its `Gemfile` to pull this gem from git ref and removing it from the gemspec in testing

```
Using rubocop 0.91.0 (was 0.85.1)
Using rubocop-performance 1.5.2
Using rubocop-rails 2.4.2
Using rubocop-rspec 1.37.1
Using salsify_gem 0.3.1
Using salsify_rubocop 0.91.0 (was 0.85.0) from https://github.com/salsify/salsify_rubocop.git (at update-rubocop-0.91.0@fce014b)
Using simplecov-html 0.12.2
Using simplecov 0.19.0
Using subprocess 1.5.3
Using svalbard 0.6.3 from source at `.`
Using vcr 5.1.0
Bundle complete! 14 Gemfile dependencies, 73 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```

And passing rubocop after

```
❯ be rubocop
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file.

Please also note that can also opt-in to new cops by default by adding this to your config:
  AllCops:
    NewCops: enable

Layout/BeginEndAlignment: # (new in 0.91)
  Enabled: true
Layout/EmptyLinesAroundAttributeAccessor: # (new in 0.83)
  Enabled: true
Layout/SpaceAroundMethodCallOperator: # (new in 0.82)
  Enabled: true
Lint/BinaryOperatorWithIdenticalOperands: # (new in 0.89)
  Enabled: true
Lint/ConstantDefinitionInBlock: # (new in 0.91)
  Enabled: true
Lint/DeprecatedOpenSSLConstant: # (new in 0.84)
  Enabled: true
Lint/DuplicateElsifCondition: # (new in 0.88)
  Enabled: true
Lint/DuplicateRequire: # (new in 0.90)
  Enabled: true
Lint/DuplicateRescueException: # (new in 0.89)
  Enabled: true
Lint/EmptyConditionalBody: # (new in 0.89)
  Enabled: true
Lint/EmptyFile: # (new in 0.90)
  Enabled: true
Lint/FloatComparison: # (new in 0.89)
  Enabled: true
Lint/IdentityComparison: # (new in 0.91)
  Enabled: true
Lint/MissingSuper: # (new in 0.89)
  Enabled: true
Lint/MixedRegexpCaptureTypes: # (new in 0.85)
  Enabled: true
Lint/OutOfRangeRegexpRef: # (new in 0.89)
  Enabled: true
Lint/RaiseException: # (new in 0.81)
  Enabled: true
Lint/SelfAssignment: # (new in 0.89)
  Enabled: true
Lint/StructNewOverride: # (new in 0.81)
  Enabled: true
Lint/TopLevelReturnWithArgument: # (new in 0.89)
  Enabled: true
Lint/TrailingCommaInAttributeDeclaration: # (new in 0.90)
  Enabled: true
Lint/UnreachableLoop: # (new in 0.89)
  Enabled: true
Lint/UselessMethodDefinition: # (new in 0.90)
  Enabled: true
Lint/UselessTimes: # (new in 0.91)
  Enabled: true
Style/AccessorGrouping: # (new in 0.87)
  Enabled: true
Style/ArrayCoercion: # (new in 0.88)
  Enabled: true
Style/BisectedAttrAccessor: # (new in 0.87)
  Enabled: true
Style/CaseLikeIf: # (new in 0.88)
  Enabled: true
Style/CombinableLoops: # (new in 0.90)
  Enabled: true
Style/ExplicitBlockArgument: # (new in 0.89)
  Enabled: true
Style/ExponentialNotation: # (new in 0.82)
  Enabled: true
Style/GlobalStdStream: # (new in 0.89)
  Enabled: true
Style/HashAsLastArrayItem: # (new in 0.88)
  Enabled: true
Style/HashEachMethods: # (new in 0.80)
  Enabled: true
Style/HashLikeCase: # (new in 0.88)
  Enabled: true
Style/HashTransformKeys: # (new in 0.80)
  Enabled: true
Style/HashTransformValues: # (new in 0.80)
  Enabled: true
Style/KeywordParametersOrder: # (new in 0.90)
  Enabled: true
Style/OptionalBooleanParameter: # (new in 0.89)
  Enabled: true
Style/RedundantAssignment: # (new in 0.87)
  Enabled: true
Style/RedundantFetchBlock: # (new in 0.86)
  Enabled: true
Style/RedundantFileExtensionInRequire: # (new in 0.88)
  Enabled: true
Style/RedundantRegexpCharacterClass: # (new in 0.85)
  Enabled: true
Style/RedundantRegexpEscape: # (new in 0.85)
  Enabled: true
Style/RedundantSelfAssignment: # (new in 0.90)
  Enabled: true
Style/SingleArgumentDig: # (new in 0.89)
  Enabled: true
Style/SlicingWithRange: # (new in 0.83)
  Enabled: true
Style/SoleNestedConditional: # (new in 0.89)
  Enabled: true
Style/StringConcatenation: # (new in 0.89)
  Enabled: true
For more information: https://docs.rubocop.org/rubocop/versioning.html
Inspecting 71 files
......................................................................C

Offenses:

svalbard.gemspec:56:3: C: Layout/LeadingCommentSpace: Missing space after #.
  #spec.add_development_dependency 'salsify_rubocop', github: 'salsify/salsify_rubocop', ref: 'update-rubocop-0.91.0'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

71 files inspected, 1 offense detected, 1 offense auto-correctable

```

Do we need to do anything with the new cops?

prime @kphelps 