### PR TITLE
Exclusions for `Rails/RakeEnvironment` and `Gemspec/RequiredRubyVersion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,17 @@
 # salsify_rubocop
 
-## 1.0.0
+## 1.0.1
+- Configure file exclusions for `Rails/RakeEnvironment` and `Gemspec/RequiredRubyVersion`
 
+## 1.0.0
 - Upgrade to `rubocop` v1.0.0
 - Upgrade to `rubocop-rspec` v2.0.0
 
 ## 0.93.1
-
 - Upgrade to `rubocop` v0.93.1
 - Add configuration for pending 1.0 cops
 
 ## 0.91.0
-
 - Upgrade to `rubocop` v0.91.0
 
 ## 0.85.0

--- a/conf/rubocop_rails.yml
+++ b/conf/rubocop_rails.yml
@@ -15,6 +15,10 @@ Rails/TimeZone:
   Exclude:
     - 'spec/**/*'
 
+Rails/RakeEnvironment:
+  Exclude:
+    - lib/tasks/auto_annotate_models.rake
+
 Rails/UniqBeforePluck:
   EnforcedStyle: aggressive
 

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -19,6 +19,10 @@ Bundler/GemComment:
     - 'github'
     - 'gist'
 
+Gemspec/RequiredRubyVersion:
+  Exclude:
+    - schemas_gem/*_schemas.gemspec
+
 # This cop has poor handling for the common case of a lambda arg in a DSL
 Lint/AmbiguousBlockAssociation:
   Enabled: false

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SalsifyRubocop
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end


### PR DESCRIPTION
This PR configures some file exclusions for the `Rails/RakeEnvironment` and `Gemspec/RequiredRubyVersion` cops.

* `Rails/RakeEnvironment`: the `auto_annotate_models` rake task doesn't load the environment
* `Gemspec/RequiredRubyVersion`: fixing this offense in the `schemas_gem` is difficult because the cop wants the required
ruby version to match the target version of the app

prime: @skarger 