### PR TITLE
Disable Bundler/GemComment version specifier checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # salsify_rubocop
 
+## 1.0.2
+- Disable version specifier checks for the `Bundler/GemComment` cop until https://github.com/rubocop/rubocop/pull/9358
+  is merged.
+
 ## 1.0.1
 - Configure file exclusions for `Rails/RakeEnvironment` and `Gemspec/RequiredRubyVersion`
 

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -10,10 +10,10 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
 
+# Don't check version_specifiers until https://github.com/rubocop/rubocop/pull/9358 merges
 Bundler/GemComment:
   Enabled: true
   OnlyFor:
-    - 'version_specifiers'
     - 'source'
     - 'git'
     - 'github'

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SalsifyRubocop
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end


### PR DESCRIPTION
This PR disables the version specifier checks in the `Bundler/GemComment` cop until https://github.com/rubocop/rubocop/pull/9358 is merged. The cop is currently generating lots of false positives when we set a minimum required gem version e.g.

```ruby
gem 'my-gem', '>= 1.11.0'
```