### PR TITLE
Test with Ruby 3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,8 @@
-version: 2
+version: 2.1
 jobs:
-  build:
+  lint:
     docker:
       - image: salsify/ruby_ci:2.5.8
-    environment:
-      CIRCLE_TEST_REPORTS: "test-results"
     working_directory: ~/salsify_rubocop
     steps:
       - checkout
@@ -23,12 +21,52 @@ jobs:
           key: v1-gems-ruby-2.5.8-{{ checksum "salsify_rubocop.gemspec" }}-{{ checksum "Gemfile" }}
           paths:
             - "vendor/bundle"
+            - "gemfiles/vendor/bundle"
       - run:
           name: Run Rubocop
-          command: bundle exec rubocop
+          command: bundle exec rubocop --config .rubocop.yml
+  test:
+    parameters:
+      ruby_version:
+        type: string
+    docker:
+      - image: salsify/ruby_ci:<< parameters.ruby_version >>
+    environment:
+      CIRCLE_TEST_REPORTS: "test-results"
+    working_directory: ~/salsify_rubocop
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-gems-ruby-<< parameters.ruby_version >>-{{ checksum "salsify_rubocop.gemspec" }}-{{ checksum "Gemfile" }}
+            - v1-gems-ruby-<< parameters.ruby_version >>-
+      - run:
+          name: Install Gems
+          command: |
+            if ! bundle check --path=vendor/bundle; then
+              bundle install --path=vendor/bundle --jobs=4 --retry=3
+              bundle clean
+            fi
+      - save_cache:
+          key: v1-gems-ruby-<< parameters.ruby_version >>-{{ checksum "salsify_rubocop.gemspec" }}-{{ checksum "Gemfile" }}
+          paths:
+            - "vendor/bundle"
+            - "gemfiles/vendor/bundle"
       - run:
           name: Run Tests
           command: |
             bundle exec rspec --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec/junit.xml --format progress spec
       - store_test_results:
           path: "test-results"
+workflows:
+  build:
+    jobs:
+      - lint
+      - test:
+          matrix:
+            parameters:
+              ruby_version:
+                - "2.5.8"
+                - "2.6.6"
+                - "2.7.2"
+                - "3.0.0"

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.4'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter'
 


### PR DESCRIPTION
This PR updates our CI configuration to test against Ruby 3.0. There were no source code changes required to get the tests passing. I also updated our version of rake while I was in there to fix a vulnerability.