### PR TITLE
Update to rubocop 1.13.0 and re-enable `Bundler/GemComment`.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: salsify/ruby_ci:2.5.8
+      - image: salsify/ruby_ci:2.6.6
     working_directory: ~/salsify_rubocop
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-gems-ruby-2.5.8-{{ checksum "salsify_rubocop.gemspec" }}-{{ checksum "Gemfile" }}
-            - v1-gems-ruby-2.5.8-
+            - v1-gems-ruby-2.6.6-{{ checksum "salsify_rubocop.gemspec" }}-{{ checksum "Gemfile" }}
+            - v1-gems-ruby-2.6.6-
       - run:
           name: Install Gems
           command: |
@@ -18,7 +18,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v1-gems-ruby-2.5.8-{{ checksum "salsify_rubocop.gemspec" }}-{{ checksum "Gemfile" }}
+          key: v1-gems-ruby-2.6.6-{{ checksum "salsify_rubocop.gemspec" }}-{{ checksum "Gemfile" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
@@ -66,7 +66,6 @@ workflows:
           matrix:
             parameters:
               ruby_version:
-                - "2.5.8"
                 - "2.6.6"
                 - "2.7.2"
                 - "3.0.0"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_from:
   - conf/rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
 Layout/LineLength:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_from:
   - conf/rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 Layout/LineLength:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # salsify_rubocop
 
+## 1.1.0
+- Re-enable version specifier checks for the `Bundler/GemComment` cop, for limiting version specifiers only.
+
 ## 1.0.2
 - Disable version specifier checks for the `Bundler/GemComment` cop until https://github.com/rubocop/rubocop/pull/9358
   is merged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.0
 - Re-enable version specifier checks for the `Bundler/GemComment` cop, for limiting version specifiers only.
 - Upgrade to `rubocop` v1.13.0
+- Drop support for Ruby 2.5 now that's in EOL
 
 ## 1.0.2
 - Disable version specifier checks for the `Bundler/GemComment` cop until https://github.com/rubocop/rubocop/pull/9358

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.1.0
 - Re-enable version specifier checks for the `Bundler/GemComment` cop, for limiting version specifiers only.
+- Upgrade to `rubocop` v1.13.0
 
 ## 1.0.2
 - Disable version specifier checks for the `Bundler/GemComment` cop until https://github.com/rubocop/rubocop/pull/9358

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -13,7 +13,7 @@ AllCops:
 Bundler/GemComment:
   Enabled: true
   OnlyFor:
-    - 'limiting_version_specifiers'
+    - 'restrictive_version_specificiers'
     - 'source'
     - 'git'
     - 'github'

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -10,10 +10,10 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
 
-# Don't check version_specifiers until https://github.com/rubocop/rubocop/pull/9358 merges
 Bundler/GemComment:
   Enabled: true
   OnlyFor:
+    - 'limiting_version_specifiers'
     - 'source'
     - 'git'
     - 'github'

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -1,3 +1,7 @@
+require:
+  - rubocop-performance
+  - rubocop-rails
+
 AllCops:
   NewCops: disable
   DisplayCopNames: true

--- a/lib/rubocop/cop/salsify/rspec_doc_string.rb
+++ b/lib/rubocop/cop/salsify/rspec_doc_string.rb
@@ -57,9 +57,9 @@ module RuboCop
         def check_quotes(doc_node)
           return unless wrong_quotes?(doc_node)
 
-          add_offense(doc_node,
-                      message: style == :single_quotes ? SINGLE_QUOTE_MSG : DOUBLE_QUOTE_MSG,
-                      &StringLiteralCorrector.correct(doc_node, style))
+          add_offense(doc_node, message: style == :single_quotes ? SINGLE_QUOTE_MSG : DOUBLE_QUOTE_MSG) do |corrector|
+            StringLiteralCorrector.correct(corrector, doc_node, style)
+          end
         end
 
         def wrong_quotes?(node)

--- a/lib/rubocop/cop/salsify/rspec_string_literals.rb
+++ b/lib/rubocop/cop/salsify/rspec_string_literals.rb
@@ -11,7 +11,8 @@ module RuboCop
       # Used together with Salsify/RspecDocString it allows one quote style to
       # be used for doc strings (`describe "foobar"`) and another style to be
       # used for all other strings in specs.
-      class RspecStringLiterals < Cop
+      class RspecStringLiterals < RuboCop::Cop::RSpec::Base
+        extend RuboCop::Cop::AutoCorrector
         include ConfigurableEnforcedStyle
         include StringLiteralsHelp
 
@@ -22,8 +23,8 @@ module RuboCop
         DOUBLE_QUOTE_MSG = 'Prefer double-quoted strings unless you need ' \
           'single quotes to avoid extra backslashes for escaping.'
 
-        def autocorrect(node)
-          StringLiteralCorrector.correct(node, style)
+        def autocorrect(corrector, node)
+          StringLiteralCorrector.correct(corrector, node, style)
         end
 
         private

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SalsifyRubocop
-  VERSION = '1.0.2'
+  VERSION = '1.1.0'
 end

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.4'
+  spec.required_ruby_version = '>= 2.5'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter'
 
-  spec.add_runtime_dependency 'rubocop', '~> 1.0.0'
+  spec.add_runtime_dependency 'rubocop', '~> 1.13.0'
   spec.add_runtime_dependency 'rubocop-performance', '~> 1.5.0'
   spec.add_runtime_dependency 'rubocop-rails', '~> 2.4.0'
   spec.add_runtime_dependency 'rubocop-rspec', '~> 2.0.0'


### PR DESCRIPTION
(as part of this [jira ticket](https://salsify.atlassian.net/browse/GCENG-458))

Follow up to https://github.com/salsify/salsify_rubocop/pull/41, as https://github.com/rubocop/rubocop/pull/9358 was merged and released as part of rubocop [1.13.0](https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#1130-2021-04-20).

Not that I agree that `>= x` version specifiers don't deserve an explanation (someone might want to know, if they'd like to downgrade for another reason) but I'm not dying on this hill 😛 

(Meant for https://github.com/salsify/con-u/pull/1752)

prime: @jturkel 
cc: @erikkessler1, @donbonifacio, @beardman 