### PR TITLE
Disable Style/ExplicitBlockArgument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # salsify_rubocop
 
+## 1.2.0
+- Disable Style/ExplicitBlockArgument for performance reasons, https://github.com/JuanitoFatas/fast-ruby/blob/master/code/proc-and-block/proc-call-vs-yield.rb.
+
 ## 1.1.0
 - Re-enable version specifier checks for the `Bundler/GemComment` cop, for limiting version specifiers only.
 - Upgrade to `rubocop` v1.13.0

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -78,6 +78,11 @@ Style/EmptyLiteral:
 Style/EmptyMethod:
   Enabled: false
 
+# Disabling due to performance implications.
+# https://github.com/JuanitoFatas/fast-ruby/blob/master/code/proc-and-block/proc-call-vs-yield.rb
+Style/ExplicitBlockArgument:
+  Enabled: false
+
 # The Exclude list is not additive. Projects that exclude file names will
 # need to re-add Appraisals.
 Naming/FileName:

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SalsifyRubocop
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end


### PR DESCRIPTION
Based on https://github.com/JuanitoFatas/fast-ruby/blob/master/code/proc-and-block/proc-call-vs-yield.rb

ruby 2.7
``` 
Warming up --------------------------------------
          block.call   700.776k i/100ms
       block + yield   709.674k i/100ms
        unused block   858.726k i/100ms
               yield     1.015M i/100ms
Calculating -------------------------------------
          block.call      6.819M (± 6.2%) i/s -     34.338M in   5.056390s
       block + yield      7.103M (±10.6%) i/s -     35.484M in   5.059581s
        unused block      8.768M (±11.7%) i/s -     43.795M in   5.076244s
               yield      9.561M (± 8.6%) i/s -     47.686M in   5.032351s

Comparison:
               yield:  9560970.9 i/s
        unused block:  8767778.8 i/s - same-ish: difference falls within error
       block + yield:  7103240.3 i/s - 1.35x  (± 0.00) slower
          block.call:  6818701.2 i/s - 1.40x  (± 0.00) slower
```

ruby 3.1
```
Warming up --------------------------------------
          block.call   568.226k i/100ms
       block + yield   671.746k i/100ms
        unused block   772.150k i/100ms
               yield   775.194k i/100ms
Calculating -------------------------------------
          block.call      6.011M (± 4.9%) i/s -     30.116M in   5.022513s
       block + yield      6.536M (± 8.1%) i/s -     32.916M in   5.078187s
        unused block      8.661M (± 6.5%) i/s -     43.240M in   5.015982s
               yield      8.193M (± 7.4%) i/s -     41.085M in   5.046509s

Comparison:
        unused block:  8660967.7 i/s
               yield:  8192521.5 i/s - same-ish: difference falls within error
       block + yield:  6535972.8 i/s - 1.33x  (± 0.00) slower
          block.call:  6011283.9 i/s - 1.44x  (± 0.00) slower
```