### PR TITLE
Set Style/HashSyntax option EnforcedShorthandSyntax: either

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # salsify_rubocop
 
+## 1.27.1
+- Set `Style/HashSyntax` option `EnforcedShorthandSyntax: either`, allowing both `{ foo: }` and `{ foo: foo }`
+
 ## 1.27.0
 - Note: Previous versions had drifted from the documented versioning scheme,
   which states that versions should match the shipped version of `rubocop`.

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -232,6 +232,10 @@ Style/HashAsLastArrayItem:
 Style/HashEachMethods:
   Enabled: false
 
+# Allow both { foo: } and { foo: foo }
+Style/HashSyntax:
+  EnforcedShorthandSyntax: either
+
 Style/OptionalBooleanParameter:
   Enabled: false
 

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SalsifyRubocop
-  VERSION = '1.27.0'
+  VERSION = '1.27.1'
 end


### PR DESCRIPTION
Set `Style/HashSyntax` option `EnforcedShorthandSyntax: either` allowing both `{ foo: }` and `{ foo: foo }`

Discussion here: https://salsify.slack.com/archives/C01DC5U1RSN/p1651606227240009