### PR TITLE
Update rubocop dependencies to latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # salsify_rubocop
 
+## 1.42.0
+- Upgrade `rubocop` to v1.42.0.
+- Upgrade `rubocop-performance` to v1.15.2.
+- Upgrade `rubocop-rails` to v2.17.4.
+- Upgrade `rubocop-rspec` to v2.16.0.
+
 ## 1.27.1
 - Set `Style/HashSyntax` option `EnforcedShorthandSyntax: either`, allowing both `{ foo: }` and `{ foo: foo }`
 
@@ -39,7 +45,7 @@
 
 ## 0.85.0
 - Upgrade to `rubocop` v0.85.0
-- Enable enforcement of Gem comments when specifying versions or sources 
+- Enable enforcement of Gem comments when specifying versions or sources
 - Drop support for Ruby 2.3, as rubocop v0.81+ doesn't support it anymore
 - Add `FrozenStringLiteralComment` and `LineLength` (max 120) rules.
 

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -179,7 +179,7 @@ Layout/LineLength:
   Enabled: true
   Max: 120
   IgnoreCopDirectives: true
-  IgnoredPatterns:
+  AllowedPatterns:
     - ^#
 
 Metrics/MethodLength:

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SalsifyRubocop
-  VERSION = '1.27.1'
+  VERSION = '1.42.0'
 end

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -37,8 +37,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter'
 
-  spec.add_runtime_dependency 'rubocop', '~> 1.27.0'
-  spec.add_runtime_dependency 'rubocop-performance', '~> 1.12.0'
-  spec.add_runtime_dependency 'rubocop-rails', '~> 2.12.0'
-  spec.add_runtime_dependency 'rubocop-rspec', '~> 2.9.0'
+  spec.add_runtime_dependency 'rubocop', '~> 1.42.0'
+  spec.add_runtime_dependency 'rubocop-performance', '~> 1.15.2'
+  spec.add_runtime_dependency 'rubocop-rails', '~> 2.17.4'
+  spec.add_runtime_dependency 'rubocop-rspec', '~> 2.16.0'
 end


### PR DESCRIPTION
* Upgrade `rubocop` to v1.42.0.
* Upgrade `rubocop-performance` to v1.15.2.
* Upgrade `rubocop-rails` to v2.17.4.
* Upgrade `rubocop-rspec` to v2.16.0.