### PR TITLE
Add tests for Ruby 3.2 and drop support for Ruby 2.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: salsify/ruby_ci:2.6.6
+      - image: salsify/ruby_ci:2.7.7
     working_directory: ~/salsify_rubocop
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-gems-ruby-2.6.6-{{ checksum "salsify_rubocop.gemspec" }}-{{ checksum "Gemfile" }}
-            - v1-gems-ruby-2.6.6-
+            - v1-gems-ruby-2.7.7-{{ checksum "salsify_rubocop.gemspec" }}-{{ checksum "Gemfile" }}
+            - v1-gems-ruby-2.7.7-
       - run:
           name: Install Gems
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ workflows:
           matrix:
             parameters:
               ruby_version:
-                - "2.6.6"
                 - "2.7.2"
                 - "3.0.0"
                 - "3.1.1"
+                - "3.2.0"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_from:
   - conf/rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 Layout/LineLength:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # salsify_rubocop
 
+## 1.42.1
+- Drop support for Ruby 2.6 as it is EOL
+- Add support for Ruby 3.2
+
 ## 1.42.0
 - Upgrade `rubocop` to v1.42.0.
 - Upgrade `rubocop-performance` to v1.15.2.

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SalsifyRubocop
-  VERSION = '1.42.0'
+  VERSION = '1.42.1'
 end

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
This PR adds Ruby 3.2 to the test matrix and drops support for Ruby 2.6 as it is EOL.

prime: @jturkel 