### PR TITLE
Configure Cops for Embedded Manifest Gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # salsify_rubocop
 
+## 1.43.1
+- Add configuration for `Gemspec/RequiredRubyVersion` cop for configuration manifest embedded gems
+
 ## 1.43.0
 - Upgrade `rubocop` to v1.43.0.
 

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -26,6 +26,7 @@ Bundler/GemComment:
 Gemspec/RequiredRubyVersion:
   Exclude:
     - schemas_gem/*_schemas.gemspec
+    - manifests_gem/*_manifests.gemspec
 
 # This cop has poor handling for the common case of a lambda arg in a DSL
 Lint/AmbiguousBlockAssociation:

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -26,7 +26,7 @@ Bundler/GemComment:
 Gemspec/RequiredRubyVersion:
   Exclude:
     - schemas_gem/*_schemas.gemspec
-    - manifests_gem/*_manifests.gemspec
+    - configuration_manifests_gem/*_configuration_manifests.gemspec
 
 # This cop has poor handling for the common case of a lambda arg in a DSL
 Lint/AmbiguousBlockAssociation:

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SalsifyRubocop
-  VERSION = '1.43.0'
+  VERSION = '1.43.1'
 end


### PR DESCRIPTION
## Problem
With the introduction of the embedded manifests gem (example [here](https://github.com/salsify/dandelion/pull/23358)), salsify_rubocop complains that the Gemspec does set the `required_ruby_version`.

## Solution
Similar to the embedded schemas gem, we should skip the check for `required_ruby_version` for the gemspec files

## Notes
I'll be waiting to merge this in until the template [here](https://github.com/salsify/rails-template/pull/253) is complete and approved in case of changes with the file naming