### PR TITLE
Disable `Gemspec/DevelopmentDependencies` cop [CPGM-595]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # salsify_rubocop
 
+## 1.59.1
+- Disable the `Gemspec/DevelopmentDependencies` cop as it goes against our current pattern for development dependencies on gems. 
+
 ## 1.59.0
 - Upgrade `rubocop` to v1.59.0 to support Ruby 3.3.
 

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -23,6 +23,9 @@ Bundler/GemComment:
     - 'github'
     - 'gist'
 
+Gemspec/DevelopmentDependencies:
+  Enabled: false
+
 Gemspec/RequiredRubyVersion:
   Exclude:
     - schemas_gem/*_schemas.gemspec

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SalsifyRubocop
-  VERSION = '1.59.0'
+  VERSION = '1.59.1'
 end


### PR DESCRIPTION
A recent version of rubocop added a default cop that forces gems to place their development dependencies in `Gemfile` instead of `<gem_name>.gemspec`: https://github.com/rubocop/rubocop/pull/11469

Here are the discussions I could find about the two ways of defining gem dev dependencies:
- https://github.com/rubygems/rubygems/discussions/5065
- https://github.com/rubygems/rubygems/issues/1104

My conclusion is that we should disable this cop.

This is for the following reasons:
- It would force us to update all our existing gems for little benefit other than complying with this cop
- It would prevent us from using the [`appraisal`](https://github.com/thoughtbot/appraisal) gem, used to test a gem against different versions of its dependencies

![image](https://github.com/salsify/salsify_rubocop/assets/8846579/95a0b067-9ec9-463a-8edb-032529c32ad8)


My opinion on this isn't strong though, so if anyone disagrees feel free to make a case for keeping it and I'll probably close this PR.

Note: originally ran into this in https://github.com/salsify/http-runner/pull/13

prime: @salsify/pim-core-backend 
CC: @salsify/network-core 