### PR TITLE
Add rubocop-rake checks to avoid method namespacing issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # salsify_rubocop
 
 ## 1.59.1
-- Add Rake specific checks with the [official extension, rubocop-rake(https://docs.rubocop.org/rubocop/extensions.html#official-extensions):
+- Add Rake specific checks with the [official extension, rubocop-rake](https://docs.rubocop.org/rubocop/extensions.html#official-extensions):
   - Enforce description (`desc`) for rake tasks, as otherwise they are not listed when `rake -T` is called
   - No duplicate namespace/task names
   - Methods/Classes shouldn't be defined inside namespaces, it's misleading because they are defined at the top level

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # salsify_rubocop
 
 ## 1.59.1
-- Add Rake specific checks:
-  - Methods shouldn't be defined namespaces as the scope is misleading and they are still defined at the top level
+- Add Rake specific checks with the [official extension, rubocop-rake(https://docs.rubocop.org/rubocop/extensions.html#official-extensions):
+  - Enforce description (`desc`) for rake tasks, as otherwise they are not listed when `rake -T` is called
+  - No duplicate namespace/task names
+  - Methods/Classes shouldn't be defined inside namespaces, it's misleading because they are defined at the top level
 
 ## 1.59.0
 - Upgrade `rubocop` to v1.59.0 to support Ruby 3.3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # salsify_rubocop
 
+## 1.59.1
+- Add Rake specific checks:
+  - Methods shouldn't be defined namespaces as the scope is misleading and they are still defined at the top level
+
 ## 1.59.0
 - Upgrade `rubocop` to v1.59.0 to support Ruby 3.3.
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,10 +6,3 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
-
-
-namespace :a_humble_test do
-  def some_method
-
-  end
-end

--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,10 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
+
+
+namespace :a_humble_test do
+  def some_method
+
+  end
+end

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -1,6 +1,7 @@
 require:
   - rubocop-performance
   - rubocop-rails
+  - rubocop-rake
 
 AllCops:
   NewCops: disable

--- a/lib/salsify_rubocop.rb
+++ b/lib/salsify_rubocop.rb
@@ -3,6 +3,7 @@
 require 'salsify_rubocop/version'
 require 'rubocop-performance'
 require 'rubocop-rails'
+require 'rubocop-rake'
 require 'rubocop-rspec'
 
 # Because RuboCop doesn't yet support plugins, we have to monkey patch in a

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SalsifyRubocop
-  VERSION = '1.59.0'
+  VERSION = '1.59.1'
 end

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -40,5 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rubocop', '~> 1.59.0'
   spec.add_runtime_dependency 'rubocop-performance', '~> 1.15.2'
   spec.add_runtime_dependency 'rubocop-rails', '~> 2.17.4'
+  spec.add_runtime_dependency 'rubocop-rake', '~> 0.6.0'
   spec.add_runtime_dependency 'rubocop-rspec', '~> 2.16.0'
 end


### PR DESCRIPTION
Adds [`rubocop-rake`](https://github.com/rubocop/rubocop-rake) checks, enabled by default.

At the suggestion of @jturkel, after I identified the root cause of a flaky test as being a method defined in a rake test inside a namespace in https://github.com/salsify/con-u/pull/5816 (the cause being that rake namespaces only work for tasks, not methods/classes, which can be very misleading and cause issues because methods/classes get defined at the top level)

![image](https://github.com/user-attachments/assets/2725522e-4e7d-456a-b0e3-3748a0f07445)

### Caveats/Notes
- I think all of these checks should be enabled by default with the exception of [Desc](https://github.com/rubocop/rubocop-rake/blob/master/lib/rubocop/cop/rake/desc.rb#L6), which enforces that every task has a description so that it is listed when someone calls `rake -T`. Any opinions on whether we should disable it?

CC: @salsify/network-core 