### PR TITLE
[GTI-1929] Upgrade to RuboCop 1.68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # salsify_rubocop
 
+## 1.68.0
+- Upgrade `rubocop` to v1.68.0.
+
 ## 1.59.1
 - Add Rake specific checks with the [official extension, rubocop-rake](https://docs.rubocop.org/rubocop/extensions.html#official-extensions):
   - Enforce description (`desc`) for rake tasks, as otherwise they are not listed when `rake -T` is called

--- a/lib/rubocop/cop/salsify/rails_unscoped.rb
+++ b/lib/rubocop/cop/salsify/rails_unscoped.rb
@@ -12,7 +12,7 @@ module RuboCop
       #
       #  # bad
       #  User.unscoped
-      class RailsUnscoped < Cop
+      class RailsUnscoped < ::RuboCop::Cop::Base
         MSG = 'Explicitly remove scopes instead of using `unscoped`.'
 
         def_node_matcher :unscoped?, <<-PATTERN
@@ -22,7 +22,7 @@ module RuboCop
         def on_send(node)
           return unless unscoped?(node)
 
-          add_offense(node, location: :expression, message: MSG)
+          add_offense(node, message: MSG)
         end
       end
     end

--- a/lib/rubocop/cop/salsify/style_dig.rb
+++ b/lib/rubocop/cop/salsify/style_dig.rb
@@ -18,10 +18,8 @@ module RuboCop
       #   my_hash['foo'] && my_hash['foo']['bar']
       #   my_array[0][1]
 
-      class StyleDig < Cop
-        extend TargetRubyVersion
-
-        minimum_target_ruby_version 2.3
+      class StyleDig < ::RuboCop::Cop::Base
+        extend RuboCop::Cop::AutoCorrector
 
         MSG = 'Use `dig` for nested access.'
 
@@ -35,7 +33,9 @@ module RuboCop
           match_node = node
           # walk to outermost access node
           match_node = match_node.parent while access_node?(match_node.parent)
-          add_offense(match_node, location: :expression, message: MSG)
+          add_offense(match_node, message: MSG) do |corrector|
+            autocorrect(match_node)[corrector]
+          end
         end
 
         def autocorrect(node)

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SalsifyRubocop
-  VERSION = '1.59.1'
+  VERSION = '1.68.0'
 end

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter'
 
-  spec.add_runtime_dependency 'rubocop', '~> 1.59.0'
+  spec.add_runtime_dependency 'rubocop', '~> 1.68.0'
   spec.add_runtime_dependency 'rubocop-performance', '~> 1.15.2'
   spec.add_runtime_dependency 'rubocop-rails', '~> 2.17.4'
   spec.add_runtime_dependency 'rubocop-rake', '~> 0.6.0'

--- a/spec/rubocop/cop/salsify/rails_unscoped_spec.rb
+++ b/spec/rubocop/cop/salsify/rails_unscoped_spec.rb
@@ -1,27 +1,23 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Salsify::RailsUnscoped, :config do
-  let(:msgs) { [described_class::MSG] }
-
   subject(:cop) { described_class.new(config) }
 
   it "accepts scopes without `unscoped`" do
-    source = 'User.where(foo: bar)'
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('User.where(foo: bar)')
   end
 
   it "detects `unscoped` in scope with explicit model" do
-    source = 'User.where(foo: bar).unscoped'
-    inspect_source(source)
-    expect(cop.highlights).to eq([source])
-    expect(cop.messages).to match_array(msgs)
+    expect_offense(<<~RUBY)
+      User.where(foo: bar).unscoped
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Explicitly remove scopes instead of using `unscoped`.
+    RUBY
   end
 
   it "detects `unscoped` in scope with implicit model" do
-    source = 'where(foo: bar).unscoped'
-    inspect_source(source)
-    expect(cop.highlights).to eq([source])
-    expect(cop.messages).to match_array(msgs)
+    expect_offense(<<~RUBY)
+      where(foo: bar).unscoped
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Explicitly remove scopes instead of using `unscoped`.
+    RUBY
   end
 end

--- a/spec/rubocop/cop/salsify/style_dig_spec.rb
+++ b/spec/rubocop/cop/salsify/style_dig_spec.rb
@@ -1,114 +1,121 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Salsify::StyleDig, :config do
-  let(:ruby_version) { 2.4 }
-  let(:msgs) { [described_class::MSG] }
+  include RuboCop::RSpec::ExpectOffense
 
   subject(:cop) { described_class.new(config) }
 
   it "accepts non-nested access" do
-    source = 'ary[0]'
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('ary[0]')
   end
 
   it "corrects nested access" do
-    source = 'hash[one][two]'
-    inspect_source(source)
-    expect(cop.highlights).to eq([source])
-    expect(cop.messages).to match_array(msgs)
-    expect(autocorrect_source(source)).to eq('hash.dig(one, two)')
+    expect_offense(<<~RUBY)
+      hash[one][two]
+      ^^^^^^^^^^^^^^ Use `dig` for nested access.
+    RUBY
+    expect_correction(<<~RUBY)
+      hash.dig(one, two)
+    RUBY
   end
 
   it "corrects triple-nested access" do
-    source = 'hash[one][two][three]'
-    inspect_source(source)
-    expect(cop.highlights).to eq([source])
-    expect(cop.messages).to match_array(msgs)
-    expect(autocorrect_source(source)).to eq('hash.dig(one, two, three)')
+    expect_offense(<<~RUBY)
+      hash[one][two][three]
+      ^^^^^^^^^^^^^^^^^^^^^ Use `dig` for nested access.
+    RUBY
+    expect_correction(<<~RUBY)
+      hash.dig(one, two, three)
+    RUBY
   end
 
   it "corrects nested access after a method call" do
-    source = 'obj.hash[:one][:two]'
-    inspect_source(source)
-    expect(cop.highlights).to eq([source])
-    expect(cop.messages).to match_array(msgs)
-    expect(autocorrect_source(source)).to eq('obj.hash.dig(:one, :two)')
+    expect_offense(<<~RUBY)
+      obj.hash[:one][:two]
+      ^^^^^^^^^^^^^^^^^^^^ Use `dig` for nested access.
+    RUBY
+    expect_correction(<<~RUBY)
+      obj.hash.dig(:one, :two)
+    RUBY
   end
 
   it "corrects nested access for a method arg" do
-    source = 'call(array[0][1])'
-    inspect_source(source)
-    expect(cop.highlights).to eq(['array[0][1]'])
-    expect(cop.messages).to match_array(msgs)
-    expect(autocorrect_source(source)).to eq('call(array.dig(0, 1))')
+    expect_offense(<<~RUBY)
+      call(array[0][1])
+           ^^^^^^^^^^^ Use `dig` for nested access.
+    RUBY
+    expect_correction(<<~RUBY)
+      call(array.dig(0, 1))
+    RUBY
   end
 
   it "corrects when a method is called after nested access" do
-    source = 'hash[one][two].foo'
-    inspect_source(source)
-    expect(cop.highlights).to eq(['hash[one][two]'])
-    expect(cop.messages).to match_array(msgs)
-    expect(autocorrect_source(source)).to eq('hash.dig(one, two).foo')
+    expect_offense(<<~RUBY)
+      hash[one][two].foo
+      ^^^^^^^^^^^^^^ Use `dig` for nested access.
+    RUBY
+    expect_correction(<<~RUBY)
+      hash.dig(one, two).foo
+    RUBY
   end
 
   it "accepts nested access on conditional assignment" do
-    source = 'foo[bar][baz] ||= 1'
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('foo[bar][baz] ||= 1')
   end
 
   it "corrects nested access in the value for conditional assignment" do
-    source = 'blah ||= foo[bar][baz]'
-    inspect_source(source)
-    expect(cop.highlights).to eq(['foo[bar][baz]'])
-    expect(cop.messages).to match_array(msgs)
-    expect(autocorrect_source(source)).to eq('blah ||= foo.dig(bar, baz)')
+    expect_offense(<<~RUBY)
+      blah ||= hash[one][two]
+               ^^^^^^^^^^^^^^ Use `dig` for nested access.
+    RUBY
+    expect_correction(<<~RUBY)
+      blah ||= hash.dig(one, two)
+    RUBY
   end
 
   it "accepts nested access for increment" do
-    source = 'foo[bar][baz] += 1'
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('foo[bar][baz] += 1')
   end
 
   it "accepts nested access for assignment" do
-    source = 'foo[bar][baz] = 0'
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('foo[bar][baz] = 0')
   end
 
   it "corrects nested access with append" do
-    source = 'foo[bar][baz] << 1'
-    inspect_source(source)
-    expect(cop.highlights).to match_array(['foo[bar][baz]'])
-    expect(cop.messages).to match_array(msgs)
-    expect(autocorrect_source(source)).to eq('foo.dig(bar, baz) << 1')
+    expect_offense(<<~RUBY)
+      foo[bar][baz] << 1
+      ^^^^^^^^^^^^^ Use `dig` for nested access.
+    RUBY
+    expect_correction(<<~RUBY)
+      foo.dig(bar, baz) << 1
+    RUBY
   end
 
   it "accepts nested access that uses an inclusive range" do
-    source = 'foo[bar][0..2]'
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('foo[bar][0..2]')
   end
 
   it "accepts nested access that uses an exclusive range" do
-    source = 'foo[bar][0...2]'
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('foo[bar][0...2]')
   end
 
   it "corrects nested access before the use of an inclusive range" do
-    source = 'foo[bar][baz][0..2]'
-    inspect_source(source)
-    expect(cop.messages).to match_array(msgs)
-    expect(autocorrect_source(source)).to eq('foo.dig(bar, baz)[0..2]')
+    expect_offense(<<~RUBY)
+      foo[bar][baz][0..2]
+      ^^^^^^^^^^^^^ Use `dig` for nested access.
+    RUBY
+    expect_correction(<<~RUBY)
+      foo.dig(bar, baz)[0..2]
+    RUBY
   end
 
   it "corrects nested access before the use of an exclusive range" do
-    source = 'foo[bar][baz][0...2]'
-    inspect_source(source)
-    expect(cop.messages).to match_array(msgs)
-    expect(autocorrect_source(source)).to eq('foo.dig(bar, baz)[0...2]')
+    expect_offense(<<~RUBY)
+      foo[bar][baz][0...2]
+      ^^^^^^^^^^^^^ Use `dig` for nested access.
+    RUBY
+    expect_correction(<<~RUBY)
+      foo.dig(bar, baz)[0...2]
+    RUBY
   end
 end


### PR DESCRIPTION
Our rails-template is failing due to some runtime errors in the `Layout/IndentationWidth` and `Layout/IndentationConsistency` cops. They seem to be related to a missing `require 'stringio'`: https://github.com/rubocop/rubocop/commit/5c04cff7421a94237b9a187eb37c80a1c2eca0a4.

This PR fixes that issue by upgrading to RuboCop 1.68 which fixes that bug. I also addressed errors around using the deprecated `Cop` in some of our custom cops.

prime: @atsheehan 

[GTI-1929]

[GTI-1929]: https://salsify.atlassian.net/browse/GTI-1929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ