### PR TITLE
[NTC-1389] Upgrade to RuboCop 1.74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # salsify_rubocop
 
+## 1.74.0
+- Upgrade `rubocop` to v1.74.0.
+
 ## 1.68.0
 - Upgrade `rubocop` to v1.68.0.
 

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SalsifyRubocop
-  VERSION = '1.68.0'
+  VERSION = '1.74.0'
 end

--- a/salsify_rubocop.gemspec
+++ b/salsify_rubocop.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter'
 
-  spec.add_runtime_dependency 'rubocop', '~> 1.68.0'
+  spec.add_runtime_dependency 'rubocop', '~> 1.74.0'
   spec.add_runtime_dependency 'rubocop-performance', '~> 1.15.2'
   spec.add_runtime_dependency 'rubocop-rails', '~> 2.17.4'
   spec.add_runtime_dependency 'rubocop-rake', '~> 0.6.0'


### PR DESCRIPTION
Updating to rubocop-sorbet 0.9 with rubocop versions below 1.72 somehow enables every single cop from that gem, instead of using the provided default configurations.

I was not able to track down the specific cause but it seems related to the introduction of rubocop plugins in 1.72, and rubocop-sorbet starting to make use of it in version 0.9

prime: @jduarte 
CC: @salsify/network-core 

[NTC-1389](https://salsify.atlassian.net/browse/NTC-1389)

[NTC-1389]: https://salsify.atlassian.net/browse/NTC-1389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ