### PR TITLE
Enforce hash shorthand syntax (Ruby 3.1+)

### DIFF
--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -234,9 +234,9 @@ Style/HashAsLastArrayItem:
 Style/HashEachMethods:
   Enabled: false
 
-# Allow both { foo: } and { foo: foo }
+# Enforce { foo: } shorthand over { foo: foo } (Ruby 3.1+)
 Style/HashSyntax:
-  EnforcedShorthandSyntax: either
+  EnforcedShorthandSyntax: always
 
 Style/OptionalBooleanParameter:
   Enabled: false


### PR DESCRIPTION
## Summary

- Changes `Style/HashSyntax` `EnforcedShorthandSyntax` from `either` to `always` in `conf/rubocop_without_rspec.yml`
- Enforces `{ a: }` over `{ a: a }` and `my_method(a:)` over `my_method(a: a)` (Ruby 3.1 shorthand)
- RuboCop automatically skips enforcement for projects with `TargetRubyVersion < 3.1`, so this is safe for older Ruby projects

## Test plan

- [ ] Run `bundle exec rubocop` in this repo — no offenses
- [ ] Verify a Ruby 3.1+ project using this gem flags verbose hash/kwarg syntax
- [ ] Verify a Ruby 3.0 project using this gem is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)