### PR TITLE
[PIMCORE-5166] Enforce Style/HashSyntax shorthand: always

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # salsify_rubocop
 
+## 1.85.3
+- Enable `Style/HashSyntax` with `EnforcedShorthandSyntax: always`.
+  Hashes whose keys match their values must now use shorthand
+  (`{ foo: }` rather than `{ foo: foo }`). Autocorrectable with
+  `rubocop -a`.
+
 ## 1.85.2
 - Add `Salsify/DelayedJobSelfEnqueue` cop to detect `Delayed::Job.enqueue(self, ...)`, which serializes memoized AR objects and can cause `Delayed::DeserializationError` if those records are deleted before the job runs.
 - Drop support for Ruby < 3.3

--- a/conf/rubocop_without_rspec.yml
+++ b/conf/rubocop_without_rspec.yml
@@ -234,9 +234,9 @@ Style/HashAsLastArrayItem:
 Style/HashEachMethods:
   Enabled: false
 
-# Allow both { foo: } and { foo: foo }
+# Enforce the shorthand syntax where the key matches the value.
 Style/HashSyntax:
-  EnforcedShorthandSyntax: either
+  EnforcedShorthandSyntax: always
 
 Style/OptionalBooleanParameter:
   Enabled: false

--- a/lib/salsify_rubocop/version.rb
+++ b/lib/salsify_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SalsifyRubocop
-  VERSION = '1.85.2'
+  VERSION = '1.85.3'
 end


### PR DESCRIPTION
## Problem

Developers were exhausting my eyeballs by repeating the key AND the value in Ruby hash literals. The extra bytes consumed by that superfluous syntax were also using up precious disk space.

## Solution

Provide new instructions for the Rubocop to annihilate the redundant syntax.

```ruby
# good
{foo:, bar:}

# good - allowed to mix syntaxes
{foo:, bar: baz}

# DESTROY DESTROY DESTROY
{foo: foo, bar: bar}
```

https://salsify.slack.com/archives/C0295DRB5K3/p1779280040849889